### PR TITLE
[mysql-schemas] MySQLDDLHistoryStore and Javadoc

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-bin.zip

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/MysqlDestinationMetrics.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/MysqlDestinationMetrics.java
@@ -18,7 +18,7 @@ import lombok.NonNull;
  * com.airbnb.spinaltap.common.destination.Destination} and associated components for a given {@link
  * MysqlSource}.
  */
-public final class MysqlDestinationMetrics extends DestinationMetrics {
+public class MysqlDestinationMetrics extends DestinationMetrics {
   private static final String DATABASE_NAME_TAG = "database_name";
   private static final String TABLE_NAME_TAG = "table_name";
 

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/MysqlSourceMetrics.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/MysqlSourceMetrics.java
@@ -42,6 +42,16 @@ public class MysqlSourceMetrics extends SourceMetrics {
   private static final String SCHEMA_DATABASE_APPLY_DDL_FAILURE_METRIC =
       MYSQL_PREFIX + ".schema_database.apply.ddl.failure.count";
 
+  private static final String DDL_HISTORY_STORE_GET_SUCCESS_METRIC =
+      MYSQL_PREFIX + ".ddl_history_store.get.success.count";
+  private static final String DDL_HISTORY_STORE_GET_FAILURE_METRIC =
+      MYSQL_PREFIX + ".ddl_history_store.get.failure.count";
+
+  private static final String DDL_HISTORY_STORE_PUT_SUCCESS_METRIC =
+      MYSQL_PREFIX + ".ddl_history_store.put.success.count";
+  private static final String DDL_HISTORY_STORE_PUT_FAILURE_METRIC =
+      MYSQL_PREFIX + ".ddl_history_store.put.failure.count";
+
   private static final String INVALID_SCHEMA_METRIC = MYSQL_PREFIX + ".table.invalid_schema.count";
   private static final String BINLOG_FILE_START_METRIC = MYSQL_PREFIX + ".binlog_file.start.count";
 
@@ -117,6 +127,22 @@ public class MysqlSourceMetrics extends SourceMetrics {
         SCHEMA_DATABASE_APPLY_DDL_FAILURE_METRIC,
         error,
         ImmutableMap.of(DATABASE_NAME_TAG, database));
+  }
+
+  public void ddlHistoryStorePutSuccess() {
+    inc(DDL_HISTORY_STORE_PUT_SUCCESS_METRIC);
+  }
+
+  public void ddlHistoryStorePutFailure(final Throwable error) {
+    incError(DDL_HISTORY_STORE_PUT_FAILURE_METRIC, error);
+  }
+
+  public void ddlHistoryStoreGetSuccess() {
+    inc(DDL_HISTORY_STORE_GET_SUCCESS_METRIC);
+  }
+
+  public void ddlHistoryStoreGetFailure(final Throwable error) {
+    incError(DDL_HISTORY_STORE_GET_FAILURE_METRIC, error);
   }
 
   public void invalidSchema(final Mutation<?> mutation) {

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/config/MysqlSchemaStoreConfiguration.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/config/MysqlSchemaStoreConfiguration.java
@@ -7,22 +7,26 @@ package com.airbnb.spinaltap.mysql.config;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
 import lombok.Data;
+import lombok.NonNull;
 
 /** Represents the configuration for a {@link com.airbnb.spinaltap.mysql.schema.MysqlSchemaStore} */
 @Data
 public class MysqlSchemaStoreConfiguration {
-  @NotNull @JsonProperty private String host;
+  @NonNull @JsonProperty private String host;
 
   @Min(0)
   @Max(65535)
   @JsonProperty
   private int port;
 
-  @NotNull @JsonProperty private String database;
+  @NonNull @JsonProperty private String database = "schema_store";
 
-  @NotNull
+  @NonNull
   @JsonProperty("archive-database")
-  private String archiveDatabase;
+  private String archiveDatabase = "schema_store_archives";
+
+  @NonNull
+  @JsonProperty("ddl-history-store-database")
+  private String ddlHistoryStoreDatabase = "ddl_history_store";
 }

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/schema/AbstractMysqlSchemaStore.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/schema/AbstractMysqlSchemaStore.java
@@ -13,6 +13,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+/** Base class for MySQL schema stores */
 @Slf4j
 @RequiredArgsConstructor
 @Getter

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/schema/CachedMysqlSchemaStore.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/schema/CachedMysqlSchemaStore.java
@@ -17,6 +17,11 @@ import javax.validation.constraints.NotNull;
 import lombok.extern.slf4j.Slf4j;
 import org.skife.jdbi.v2.DBI;
 
+/**
+ * Represents a cached implementation of {@link com.airbnb.spinaltap.mysql.schema.SchemaStore}. This
+ * class acts as a proxy for {@link com.airbnb.spinaltap.mysql.schema.MysqlSchemaStore} and caches
+ * the schema information in memory
+ */
 @Slf4j
 public class CachedMysqlSchemaStore extends AbstractMysqlSchemaStore
     implements SchemaStore<MysqlTableSchema> {

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/schema/LatestMysqlSchemaStore.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/schema/LatestMysqlSchemaStore.java
@@ -21,6 +21,10 @@ import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.util.StringColumnMapper;
 
+/**
+ * Represents the current(latest) snapshot of MySQL schema. Schema queries will hit MySQL
+ * information_schema.
+ */
 @Slf4j
 public class LatestMysqlSchemaStore extends AbstractMysqlSchemaStore
     implements SchemaStore<MysqlTableSchema> {

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/schema/MysqlDDLHistoryStore.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/schema/MysqlDDLHistoryStore.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright 2018 Airbnb. Licensed under Apache-2.0. See License in the project root for license
+ * information.
+ */
+package com.airbnb.spinaltap.mysql.schema;
+
+import com.airbnb.spinaltap.mysql.BinlogFilePos;
+import com.airbnb.spinaltap.mysql.MysqlSourceMetrics;
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import org.skife.jdbi.v2.util.StringColumnMapper;
+
+@Slf4j
+@RequiredArgsConstructor
+public class MysqlDDLHistoryStore {
+  @NonNull private final String source;
+  @NonNull private final DBI jdbi;
+  @NonNull private final String archiveDatabase;
+  @NonNull private final MysqlSourceMetrics metrics;
+
+  private static final String PUT_DDL_HISTORY_QUERY =
+      "INSERT INTO `%s` " + "(`binlog_position`, `DDL`, `created_at`) " + "VALUES (?, ?, ?)";
+  private static final String GET_DDL_HISTORY_QUERY =
+      "SELECT DDL FROM `%s` " + "WHERE `binlog_position` = :binlog_position";
+  private static final String CREATE_DDL_HISTORY_STORE_TABLE_QUERY =
+      "CREATE TABLE IF NOT EXISTS `%s` ("
+          + "`id` int(11) unsigned NOT NULL AUTO_INCREMENT,"
+          + "`binlog_position` varchar(255) NOT NULL,"
+          + "`DDL` longtext NOT NULL,"
+          + "`created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,"
+          + "  PRIMARY KEY (`id`),"
+          + "  UNIQUE KEY `binlog_position_index` (`binlog_position`)"
+          + ") ENGINE=InnoDB DEFAULT CHARSET=utf8";
+  private static final String ARCHIVE_DDL_HISTORY_STORE_TABLE_QUERY =
+      "RENAME TABLE `%s` TO `%s`.`%s`";
+
+  public void put(@NonNull BinlogFilePos binlogFilePos, @NonNull String ddl, long timestamp) {
+    try (Handle handle = jdbi.open()) {
+      MysqlSchemaUtil.VOID_RETRYER.call(
+          () -> {
+            handle.insert(
+                String.format(PUT_DDL_HISTORY_QUERY, source),
+                binlogFilePos.toString(),
+                ddl,
+                new Timestamp(timestamp));
+            return null;
+          });
+      metrics.ddlHistoryStorePutSuccess();
+    } catch (Exception ex) {
+      log.error(
+          String.format("Failed to put into DDL History store. source: %s. DDL: %s", source, ddl));
+      metrics.ddlHistoryStorePutFailure(ex);
+      throw new RuntimeException(ex);
+    }
+  }
+
+  public String get(@NonNull BinlogFilePos binlogFilePos) {
+    try (Handle handle = jdbi.open()) {
+      String ddl =
+          MysqlSchemaUtil.STRING_RETRYER.call(
+              () ->
+                  handle
+                      .createQuery(String.format(GET_DDL_HISTORY_QUERY, source))
+                      .bind("binlog_position", binlogFilePos.toString())
+                      .map(StringColumnMapper.INSTANCE)
+                      .first());
+      metrics.ddlHistoryStoreGetSuccess();
+      return ddl;
+    } catch (Exception ex) {
+      log.error(
+          String.format("Failed to get DDL for binlog_position %s. Does it exist?", binlogFilePos),
+          ex);
+      metrics.ddlHistoryStoreGetFailure(ex);
+      throw new RuntimeException(ex);
+    }
+  }
+
+  public void create() {
+    try (Handle handle = jdbi.open()) {
+      MysqlSchemaUtil.VOID_RETRYER.call(
+          () -> {
+            handle.execute(String.format(CREATE_DDL_HISTORY_STORE_TABLE_QUERY, source));
+            return null;
+          });
+    } catch (Exception ex) {
+      log.error(
+          String.format(
+              "Failed to create DDL history store for source: %s. (Exception: %s)", source, ex));
+      throw new RuntimeException(ex);
+    }
+  }
+
+  public void archive() {
+    try (Handle handle = jdbi.open()) {
+      String archiveTableName =
+          String.format(
+              "%s_ddl_history_%s",
+              source, new SimpleDateFormat("yyyyMMddHHmmss").format(new Date()));
+      MysqlSchemaUtil.VOID_RETRYER.call(
+          () -> {
+            handle.execute(
+                String.format(
+                    ARCHIVE_DDL_HISTORY_STORE_TABLE_QUERY,
+                    source,
+                    archiveDatabase,
+                    archiveTableName));
+            return null;
+          });
+      log.info("DDL history store for {} has been archived as {}", source, archiveTableName);
+    } catch (Exception ex) {
+      log.error(
+          String.format(
+              "Failed to archive DDL history store for source: %s. (Exception: %s)", source, ex));
+      throw new RuntimeException(ex);
+    }
+  }
+}

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/schema/MysqlDDLHistoryStore.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/schema/MysqlDDLHistoryStore.java
@@ -16,6 +16,7 @@ import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.util.StringColumnMapper;
 
+/** Represents a MySQL table to keep track of all processed DDL statements */
 @Slf4j
 @RequiredArgsConstructor
 public class MysqlDDLHistoryStore {

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/schema/MysqlSchemaDatabase.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/schema/MysqlSchemaDatabase.java
@@ -26,6 +26,11 @@ import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.util.StringColumnMapper;
 
+/**
+ * Snapshots of MySQL tables. DDL statements in binlog are transformed and applied to tables in
+ * MySQL schema database. Updated table schemas are fetched from schema database and put into the
+ * schema store.
+ */
 @Slf4j
 public class MysqlSchemaDatabase {
   private static final char DELIMITER = '/';

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/schema/MysqlSchemaStore.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/schema/MysqlSchemaStore.java
@@ -23,6 +23,10 @@ import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.util.IntegerColumnMapper;
 import org.skife.jdbi.v2.util.StringColumnMapper;
 
+/**
+ * Represents an implementation of {@link com.airbnb.spinaltap.mysql.schema.SchemaStore} which
+ * stores the schema history in MySQL table
+ */
 @Slf4j
 public class MysqlSchemaStore extends AbstractMysqlSchemaStore
     implements SchemaStore<MysqlTableSchema> {

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/schema/MysqlSchemaStoreManager.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/schema/MysqlSchemaStoreManager.java
@@ -22,6 +22,7 @@ public class MysqlSchemaStoreManager implements SchemaStoreBootstrapper, SchemaS
   @NonNull private final LatestMysqlSchemaStore schemaReader;
   @NonNull private final MysqlSchemaStore schemaStore;
   @NonNull private final MysqlSchemaDatabase schemaDatabase;
+  @NonNull private final MysqlDDLHistoryStore ddlHistoryStore;
 
   public void bootstrap(@NotNull final String database) {
     Preconditions.checkState(
@@ -51,6 +52,7 @@ public class MysqlSchemaStoreManager implements SchemaStoreBootstrapper, SchemaS
             "%s seems to be bootstrapped already. Please archive it first if you would like to bootstrap again.",
             source));
 
+    ddlHistoryStore.create();
     schemaStore.create();
     schemaReader.listAllDatabases().forEach(this::bootstrap);
   }
@@ -70,5 +72,6 @@ public class MysqlSchemaStoreManager implements SchemaStoreBootstrapper, SchemaS
     log.info("Archiving schema store for {}", source);
     schemaDatabase.dropDatabases();
     schemaStore.archive();
+    ddlHistoryStore.archive();
   }
 }

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/schema/MysqlSchemaStoreManager.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/schema/MysqlSchemaStoreManager.java
@@ -12,6 +12,11 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+/**
+ * Represents an implementation of {@link com.airbnb.spinaltap.mysql.schema.SchemaStoreBootstrapper}
+ * and {@link com.airbnb.spinaltap.mysql.schema.SchemaStoreArchiver} which bootstraps and archives
+ * schema stores.
+ */
 @Slf4j
 @RequiredArgsConstructor
 public class MysqlSchemaStoreManager implements SchemaStoreBootstrapper, SchemaStoreArchiver {

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/schema/MysqlSchemaStoreManagerFactory.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/schema/MysqlSchemaStoreManagerFactory.java
@@ -7,11 +7,14 @@ package com.airbnb.spinaltap.mysql.schema;
 import com.airbnb.spinaltap.mysql.MysqlSourceMetrics;
 import com.airbnb.spinaltap.mysql.config.MysqlConfiguration;
 import com.airbnb.spinaltap.mysql.config.MysqlSchemaStoreConfiguration;
-import javax.validation.constraints.NotNull;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.skife.jdbi.v2.DBI;
 
+/**
+ * The factory class of {@link com.airbnb.spinaltap.mysql.schema.MysqlSchemaStoreManager} which
+ * provides necessary initialization and setups.
+ */
 @RequiredArgsConstructor
 public class MysqlSchemaStoreManagerFactory {
   @NonNull private final String mysqlUser;
@@ -19,9 +22,9 @@ public class MysqlSchemaStoreManagerFactory {
   @NonNull private final MysqlSchemaStoreConfiguration schemaStoreConfiguration;
 
   public MysqlSchemaStoreManager create(
-      @NotNull final String source,
-      @NotNull final MysqlConfiguration mysqlConfiguration,
-      @NotNull final MysqlSourceMetrics metrics) {
+      @NonNull final String source,
+      @NonNull final MysqlConfiguration mysqlConfiguration,
+      @NonNull final MysqlSourceMetrics metrics) {
     final DBI schemaReaderDBI =
         MysqlSchemaUtil.createMysqlDBI(
             mysqlConfiguration.getHost(),
@@ -65,7 +68,7 @@ public class MysqlSchemaStoreManagerFactory {
   }
 
   public SchemaStoreArchiver createArchiver(
-      @NotNull final String source, @NotNull final MysqlSourceMetrics metrics) {
+      @NonNull final String source, @NonNull final MysqlSourceMetrics metrics) {
     final DBI schemaStoreDBI =
         MysqlSchemaUtil.createMysqlDBI(
             schemaStoreConfiguration.getHost(),

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/schema/MysqlSchemaStoreManagerFactory.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/schema/MysqlSchemaStoreManagerFactory.java
@@ -46,12 +46,22 @@ public class MysqlSchemaStoreManagerFactory {
             mysqlPassword,
             null);
 
+    final DBI ddlHistoryStoreDBI =
+        MysqlSchemaUtil.createMysqlDBI(
+            schemaStoreConfiguration.getHost(),
+            schemaStoreConfiguration.getPort(),
+            mysqlUser,
+            mysqlPassword,
+            schemaStoreConfiguration.getDdlHistoryStoreDatabase());
+
     return new MysqlSchemaStoreManager(
         source,
         new LatestMysqlSchemaStore(source, schemaReaderDBI, metrics),
         new MysqlSchemaStore(
             source, schemaStoreDBI, schemaStoreConfiguration.getArchiveDatabase(), metrics),
-        new MysqlSchemaDatabase(source, schemaDatabaseDBI, metrics));
+        new MysqlSchemaDatabase(source, schemaDatabaseDBI, metrics),
+        new MysqlDDLHistoryStore(
+            source, ddlHistoryStoreDBI, schemaStoreConfiguration.getArchiveDatabase(), metrics));
   }
 
   public SchemaStoreArchiver createArchiver(
@@ -72,11 +82,21 @@ public class MysqlSchemaStoreManagerFactory {
             mysqlPassword,
             null);
 
+    final DBI ddlHistoryStoreDBI =
+        MysqlSchemaUtil.createMysqlDBI(
+            schemaStoreConfiguration.getHost(),
+            schemaStoreConfiguration.getPort(),
+            mysqlUser,
+            mysqlPassword,
+            schemaStoreConfiguration.getDdlHistoryStoreDatabase());
+
     return new MysqlSchemaStoreManager(
         source,
         null,
         new MysqlSchemaStore(
             source, schemaStoreDBI, schemaStoreConfiguration.getArchiveDatabase(), metrics),
-        new MysqlSchemaDatabase(source, schemaDatabaseDBI, metrics));
+        new MysqlSchemaDatabase(source, schemaDatabaseDBI, metrics),
+        new MysqlDDLHistoryStore(
+            source, ddlHistoryStoreDBI, schemaStoreConfiguration.getArchiveDatabase(), metrics));
   }
 }

--- a/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/schema/MysqlSchemaTrackerTest.java
+++ b/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/schema/MysqlSchemaTrackerTest.java
@@ -125,6 +125,7 @@ public class MysqlSchemaTrackerTest {
 
   private final SchemaStore<MysqlTableSchema> schemaStore = mock(CachedMysqlSchemaStore.class);
   private final MysqlSchemaDatabase schemaDatabase = mock(MysqlSchemaDatabase.class);
+  private final MysqlDDLHistoryStore ddlHistoryStore = mock(MysqlDDLHistoryStore.class);
   private final BinlogFilePos binlogFilePos = new BinlogFilePos("mysql-bin-changelog.000332");
   private final QueryEvent queryEvent =
       new QueryEvent(
@@ -137,6 +138,7 @@ public class MysqlSchemaTrackerTest {
   @Before
   public void setUp() throws Exception {
     when(schemaStore.get(binlogFilePos)).thenReturn(null);
+    when(ddlHistoryStore.get(binlogFilePos)).thenReturn(null);
   }
 
   @Test
@@ -167,7 +169,7 @@ public class MysqlSchemaTrackerTest {
     when(schemaStore.getAll()).thenReturn(allTableSchemaInStore);
     when(schemaDatabase.fetchTableSchema(DATABASE_NAME)).thenReturn(tableSchemaMapInSchemaDatabase);
 
-    SchemaTracker schemaTracker = new MysqlSchemaTracker(schemaStore, schemaDatabase);
+    SchemaTracker schemaTracker = new MysqlSchemaTracker(schemaStore, schemaDatabase, ddlHistoryStore);
 
     schemaTracker.processDDLStatement(queryEvent);
 
@@ -209,7 +211,7 @@ public class MysqlSchemaTrackerTest {
     when(schemaStore.getAll()).thenReturn(allTableSchemaInStore);
     when(schemaDatabase.fetchTableSchema(DATABASE_NAME)).thenReturn(tableSchemaMapInSchemaDatabase);
 
-    SchemaTracker schemaTracker = new MysqlSchemaTracker(schemaStore, schemaDatabase);
+    SchemaTracker schemaTracker = new MysqlSchemaTracker(schemaStore, schemaDatabase, ddlHistoryStore);
 
     schemaTracker.processDDLStatement(queryEvent);
 
@@ -267,7 +269,7 @@ public class MysqlSchemaTrackerTest {
     when(schemaStore.getAll()).thenReturn(allTableSchemaInStore);
     when(schemaDatabase.fetchTableSchema(DATABASE_NAME)).thenReturn(tableSchemaMapInSchemaDatabase);
 
-    SchemaTracker schemaTracker = new MysqlSchemaTracker(schemaStore, schemaDatabase);
+    SchemaTracker schemaTracker = new MysqlSchemaTracker(schemaStore, schemaDatabase, ddlHistoryStore);
 
     schemaTracker.processDDLStatement(queryEvent);
 
@@ -309,7 +311,7 @@ public class MysqlSchemaTrackerTest {
     when(schemaStore.getAll()).thenReturn(allTableSchemaInStore);
     when(schemaDatabase.fetchTableSchema(DATABASE_NAME)).thenReturn(tableSchemaMapInSchemaDatabase);
 
-    SchemaTracker schemaTracker = new MysqlSchemaTracker(schemaStore, schemaDatabase);
+    SchemaTracker schemaTracker = new MysqlSchemaTracker(schemaStore, schemaDatabase, ddlHistoryStore);
 
     schemaTracker.processDDLStatement(queryEvent);
 
@@ -381,7 +383,7 @@ public class MysqlSchemaTrackerTest {
     when(schemaStore.getAll()).thenReturn(allTableSchemaInStore);
     when(schemaDatabase.fetchTableSchema(DATABASE_NAME)).thenReturn(tableSchemaMapInSchemaDatabase);
 
-    SchemaTracker schemaTracker = new MysqlSchemaTracker(schemaStore, schemaDatabase);
+    SchemaTracker schemaTracker = new MysqlSchemaTracker(schemaStore, schemaDatabase, ddlHistoryStore);
 
     schemaTracker.processDDLStatement(queryEvent);
 
@@ -434,7 +436,7 @@ public class MysqlSchemaTrackerTest {
     QueryEvent queryEvent =
         new QueryEvent(0, 0, binlogFilePos, DATABASE2_NAME, "CREATE DATABASE `database2`");
 
-    SchemaTracker schemaTracker = new MysqlSchemaTracker(schemaStore, schemaDatabase);
+    SchemaTracker schemaTracker = new MysqlSchemaTracker(schemaStore, schemaDatabase, ddlHistoryStore);
 
     schemaTracker.processDDLStatement(queryEvent);
 
@@ -487,7 +489,7 @@ public class MysqlSchemaTrackerTest {
     QueryEvent queryEvent =
         new QueryEvent(0, 0, binlogFilePos, DATABASE2_NAME, "DROP DATABASE `database1`");
 
-    SchemaTracker schemaTracker = new MysqlSchemaTracker(schemaStore, schemaDatabase);
+    SchemaTracker schemaTracker = new MysqlSchemaTracker(schemaStore, schemaDatabase, ddlHistoryStore);
 
     schemaTracker.processDDLStatement(queryEvent);
 

--- a/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/schema/MysqlSchemaTrackerTest.java
+++ b/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/schema/MysqlSchemaTrackerTest.java
@@ -169,7 +169,8 @@ public class MysqlSchemaTrackerTest {
     when(schemaStore.getAll()).thenReturn(allTableSchemaInStore);
     when(schemaDatabase.fetchTableSchema(DATABASE_NAME)).thenReturn(tableSchemaMapInSchemaDatabase);
 
-    SchemaTracker schemaTracker = new MysqlSchemaTracker(schemaStore, schemaDatabase, ddlHistoryStore);
+    SchemaTracker schemaTracker =
+        new MysqlSchemaTracker(schemaStore, schemaDatabase, ddlHistoryStore);
 
     schemaTracker.processDDLStatement(queryEvent);
 
@@ -211,7 +212,8 @@ public class MysqlSchemaTrackerTest {
     when(schemaStore.getAll()).thenReturn(allTableSchemaInStore);
     when(schemaDatabase.fetchTableSchema(DATABASE_NAME)).thenReturn(tableSchemaMapInSchemaDatabase);
 
-    SchemaTracker schemaTracker = new MysqlSchemaTracker(schemaStore, schemaDatabase, ddlHistoryStore);
+    SchemaTracker schemaTracker =
+        new MysqlSchemaTracker(schemaStore, schemaDatabase, ddlHistoryStore);
 
     schemaTracker.processDDLStatement(queryEvent);
 
@@ -269,7 +271,8 @@ public class MysqlSchemaTrackerTest {
     when(schemaStore.getAll()).thenReturn(allTableSchemaInStore);
     when(schemaDatabase.fetchTableSchema(DATABASE_NAME)).thenReturn(tableSchemaMapInSchemaDatabase);
 
-    SchemaTracker schemaTracker = new MysqlSchemaTracker(schemaStore, schemaDatabase, ddlHistoryStore);
+    SchemaTracker schemaTracker =
+        new MysqlSchemaTracker(schemaStore, schemaDatabase, ddlHistoryStore);
 
     schemaTracker.processDDLStatement(queryEvent);
 
@@ -311,7 +314,8 @@ public class MysqlSchemaTrackerTest {
     when(schemaStore.getAll()).thenReturn(allTableSchemaInStore);
     when(schemaDatabase.fetchTableSchema(DATABASE_NAME)).thenReturn(tableSchemaMapInSchemaDatabase);
 
-    SchemaTracker schemaTracker = new MysqlSchemaTracker(schemaStore, schemaDatabase, ddlHistoryStore);
+    SchemaTracker schemaTracker =
+        new MysqlSchemaTracker(schemaStore, schemaDatabase, ddlHistoryStore);
 
     schemaTracker.processDDLStatement(queryEvent);
 
@@ -383,7 +387,8 @@ public class MysqlSchemaTrackerTest {
     when(schemaStore.getAll()).thenReturn(allTableSchemaInStore);
     when(schemaDatabase.fetchTableSchema(DATABASE_NAME)).thenReturn(tableSchemaMapInSchemaDatabase);
 
-    SchemaTracker schemaTracker = new MysqlSchemaTracker(schemaStore, schemaDatabase, ddlHistoryStore);
+    SchemaTracker schemaTracker =
+        new MysqlSchemaTracker(schemaStore, schemaDatabase, ddlHistoryStore);
 
     schemaTracker.processDDLStatement(queryEvent);
 
@@ -436,7 +441,8 @@ public class MysqlSchemaTrackerTest {
     QueryEvent queryEvent =
         new QueryEvent(0, 0, binlogFilePos, DATABASE2_NAME, "CREATE DATABASE `database2`");
 
-    SchemaTracker schemaTracker = new MysqlSchemaTracker(schemaStore, schemaDatabase, ddlHistoryStore);
+    SchemaTracker schemaTracker =
+        new MysqlSchemaTracker(schemaStore, schemaDatabase, ddlHistoryStore);
 
     schemaTracker.processDDLStatement(queryEvent);
 
@@ -489,7 +495,8 @@ public class MysqlSchemaTrackerTest {
     QueryEvent queryEvent =
         new QueryEvent(0, 0, binlogFilePos, DATABASE2_NAME, "DROP DATABASE `database1`");
 
-    SchemaTracker schemaTracker = new MysqlSchemaTracker(schemaStore, schemaDatabase, ddlHistoryStore);
+    SchemaTracker schemaTracker =
+        new MysqlSchemaTracker(schemaStore, schemaDatabase, ddlHistoryStore);
 
     schemaTracker.processDDLStatement(queryEvent);
 


### PR DESCRIPTION
Issue
---
When processing DDL statements in [MySQLSchemaTracker](https://github.com/airbnb/SpinalTap/blob/a4fc0433b389fc3070bd75f9cc73abcba0c1ef05/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/schema/MysqlSchemaTracker.java#L34), we check if there's a schema version in `SchemaStore`. 
However, only DDL statements that caused table schema updates (such as ALTER TABLE ADD/DELETE COLUMN) will results a new schema version in `SchemaStore`, statements like `ALTER TABLE CREATE/DROP INDEX` won't be saved in `SchemaStore`. If SpinalTap is rewinded, such statements will be applied again and fail in `MySQLSchemaDatabase` (The same index cannot be created or dropped more than once).

Proposed Solution
---
This PR adds a `MySQLDDLHistoryStore` which stores all processed DDL statements. Before processing a DDL statement, we query from this history store and skip if it has already been applied.

Other changes
---
* Added javadoc to mysql schema source code

Changes were verified locally.

@jadabisamra @mangobatao 