### PR TITLE
Make destination type configurable

### DIFF
--- a/spinaltap-common/src/main/java/com/airbnb/spinaltap/common/config/DestinationConfiguration.java
+++ b/spinaltap-common/src/main/java/com/airbnb/spinaltap/common/config/DestinationConfiguration.java
@@ -9,14 +9,21 @@ import javax.validation.constraints.Min;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 
 /** Represents a {@link com.airbnb.spinaltap.common.destination.Destination} configuration. */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 public class DestinationConfiguration {
+  public static final String DEFAULT_TYPE = "kafka";
   public static final int DEFAULT_BUFFER_SIZE = 0;
   public static final int DEFAULT_POOL_SIZE = 0;
+
+  /** The destination type. Default to "kafka". */
+  @NonNull
+  @JsonProperty("type")
+  private String type = DEFAULT_TYPE;
 
   /**
    * The buffer size. If greater than 0, a {@link

--- a/spinaltap-standalone/src/main/java/com/airbnb/spinaltap/SpinalTapStandaloneApp.java
+++ b/spinaltap-standalone/src/main/java/com/airbnb/spinaltap/SpinalTapStandaloneApp.java
@@ -11,6 +11,7 @@ import com.airbnb.spinaltap.mysql.MysqlPipeFactory;
 import com.airbnb.spinaltap.mysql.config.MysqlConfiguration;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.common.collect.ImmutableMap;
 import java.io.File;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.curator.framework.CuratorFramework;
@@ -52,7 +53,7 @@ public final class SpinalTapStandaloneApp {
         config.getMysqlUser(),
         config.getMysqlPassword(),
         config.getMysqlServerId(),
-        () -> new KafkaDestinationBuilder<>(config.getKafkaProducerConfig()),
+        ImmutableMap.of("kafka", new KafkaDestinationBuilder<>(config.getKafkaProducerConfig())),
         config.getMysqlSchemaStoreConfig(),
         new TaggedMetricRegistry());
   }


### PR DESCRIPTION
Make destination type configurable by source. Default to `kafka`.

@mangobatao 