### PR TITLE
Allow different server_id for each source

### DIFF
--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/MysqlSourceFactory.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/MysqlSourceFactory.java
@@ -52,9 +52,15 @@ public class MysqlSourceFactory {
     final DBI mysqlDBI = MysqlSchemaUtil.createMysqlDBI(host, port, user, password, null);
 
     final BinaryLogClient client = new BinaryLogClient(host, port, user, password);
-    // Set different server_id for staging and production environment.
-    // Conflict occurs when more than one client of same server_id connect to a MySQL server.
-    client.setServerId(serverId);
+
+    /* Override the global server_id if it is set in MysqlConfiguration
+      Allow each source to use a different server_id
+    */
+    if (configuration.getServerId() != MysqlConfiguration.DEFAULT_SERVER_ID) {
+      client.setServerId(configuration.getServerId());
+    } else {
+      client.setServerId(serverId);
+    }
 
     final DataSource dataSource = new DataSource(host, port, name);
 

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/config/MysqlConfiguration.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/config/MysqlConfiguration.java
@@ -33,6 +33,7 @@ public class MysqlConfiguration extends AbstractMysqlConfiguration {
   public static final HostRole DEFAULT_HOST_ROLE = HostRole.MASTER;
   public static final int DEFAULT_SOCKET_TIMEOUT_IN_SECONDS = 90;
   public static final int DEFAULT_PORT = 5672;
+  public static final int DEFAULT_SERVER_ID = -1;
   public static final boolean DEFAULT_SCHEMA_VERSION_ENABLED = false;
   public static final boolean DEFAULT_LARGE_MESSAGE_ENABLED = false;
   public static final long DEFAULT_DELAY_SEND_MS = 0L;
@@ -77,6 +78,11 @@ public class MysqlConfiguration extends AbstractMysqlConfiguration {
   @Max(65535)
   @JsonProperty
   private int port = DEFAULT_PORT;
+
+  /** Setting a non-default server_id overrides the value in the global config */
+  @Min(-1)
+  @JsonProperty("server_id")
+  private int serverId = DEFAULT_SERVER_ID;
 
   @JsonProperty("socket_timeout_seconds")
   private int socketTimeoutInSeconds = DEFAULT_SOCKET_TIMEOUT_IN_SECONDS;


### PR DESCRIPTION
Allow each source to use a `server_id` that is different from the global config, in case multiple sources connect to the same MySQL server and their `server_id` conflict.
@mangobatao 