### PR TITLE
Add COLLATE=utf8_bin to MysqlSchemaStore

### DIFF
--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/schema/MysqlSchemaStore.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/schema/MysqlSchemaStore.java
@@ -71,7 +71,7 @@ public class MysqlSchemaStore extends AbstractMysqlSchemaStore
           + "  KEY `version_index` (`version`),"
           + "  UNIQUE KEY `binlog_position_index` (`source`,`database`,`table`,`binlog_filename`,`binlog_position`),"
           + "  UNIQUE KEY `version_query_index` (`source`,`database`,`table`,`version`)"
-          + ") ENGINE=InnoDB DEFAULT CHARSET=utf8";
+          + ") ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin";
   private static final String ARCHIVE_SCHEMA_STORE_TABLE_QUERY = "RENAME TABLE `%s` TO `%s`.`%s`";
   private static final String CREATE_ARCHIVE_TABLE_QUERY = "CREATE TABLE `%s`.`%s` LIKE `%s`";
   private static final String INSERT_ARCHIVE_TABLE_QUERY =


### PR DESCRIPTION
When `lower_case_table_names` is set to 0 MySQL tables are case-sensitive and both `user` and `USER` table can exist in the same db. The unique key constraint (`UNIQUE KEY binlog_position_index (source,database,table,binlog_filename,binlog_position)`) may cause problem when bootstrapping schema store. Setting `COLLATE=utf8_bin` will allow case-sensitive table names.

Verified locally.

@mangobatao @jadabisamra 