### PR TITLE
SchemaStore and Kafka topic name update

### DIFF
--- a/spinaltap-kafka/src/main/java/com/airbnb/spinaltap/kafka/KafkaDestination.java
+++ b/spinaltap-kafka/src/main/java/com/airbnb/spinaltap/kafka/KafkaDestination.java
@@ -126,7 +126,7 @@ public final class KafkaDestination<T extends TBase<?, ?>> extends AbstractDesti
     return String.format(
         "%s.%s-%s-%s",
         topicNamePrefix,
-        mutation.getDataSource().getHostname(),
+        mutation.getDataSource().getSynapseService(),
         mutation.getTable().getDatabase(),
         mutation.getTable().getName());
   }

--- a/spinaltap-kafka/src/test/java/com/airbnb/spinaltap/kafka/KafkaDestinationTest.java
+++ b/spinaltap-kafka/src/test/java/com/airbnb/spinaltap/kafka/KafkaDestinationTest.java
@@ -51,10 +51,12 @@ public class KafkaDestinationTest extends AbstractKafkaIntegrationTestHarness {
   private static final int SESSION_TIMEOUT_MS = 10000;
   private static final int CONNECTION_TIMEOUT_MS = 10000;
   private static final ZkSerializer ZK_SERIALIZER = ZKStringSerializer$.MODULE$;
-  private static final String HOSTNAME = "localhost";
+  private static final String SOURCE_NAME = "localhost";
+  private static final String HOSTNAME = "127.0.0.1";
   private static final String DATABASE = "database";
   private static final String TABLE = "table";
-  private static final String TOPIC = "spinaltap" + "." + HOSTNAME + "-" + DATABASE + "-" + TABLE;
+  private static final String TOPIC =
+      "spinaltap" + "." + SOURCE_NAME + "-" + DATABASE + "-" + TABLE;
   private static final ThreadLocal<TDeserializer> deserializer =
       ThreadLocal.withInitial(() -> new TDeserializer((new TBinaryProtocol.Factory())));
 
@@ -178,7 +180,7 @@ public class KafkaDestinationTest extends AbstractKafkaIntegrationTestHarness {
             ImmutableList.of("id"));
     MysqlMutationMetadata metadata =
         new MysqlMutationMetadata(
-            new DataSource(HOSTNAME, 0, "service"),
+            new DataSource(HOSTNAME, 0, SOURCE_NAME),
             new BinlogFilePos(),
             table,
             0L,

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/MysqlPipeFactory.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/MysqlPipeFactory.java
@@ -49,7 +49,7 @@ public final class MysqlPipeFactory extends AbstractPipeFactory<MysqlConfigurati
       @Min(0) final long mysqlServerId,
       @NonNull
           final Map<String, Supplier<DestinationBuilder<Mutation>>> destinationBuilderSupplierMap,
-      @NonNull final MysqlSchemaStoreConfiguration schemaStoreConfig,
+      final MysqlSchemaStoreConfiguration schemaStoreConfig,
       @NonNull final TaggedMetricRegistry metricRegistry) {
     super(metricRegistry);
     this.mysqlUser = mysqlUser;

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/MysqlSourceFactory.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/MysqlSourceFactory.java
@@ -25,6 +25,7 @@ import com.airbnb.spinaltap.mysql.schema.SchemaTracker;
 import com.airbnb.spinaltap.mysql.validator.EventOrderValidator;
 import com.airbnb.spinaltap.mysql.validator.MutationSchemaValidator;
 import com.github.shyiko.mysql.binlog.BinaryLogClient;
+import com.google.common.base.Preconditions;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.concurrent.atomic.AtomicLong;
@@ -43,7 +44,7 @@ public class MysqlSourceFactory {
       @Min(0) final long serverId,
       @NonNull final Repository<SourceState> backingStateRepository,
       @NonNull final Repository<Collection<SourceState>> stateHistoryRepository,
-      @NonNull final MysqlSchemaStoreConfiguration schemaStoreConfig,
+      final MysqlSchemaStoreConfiguration schemaStoreConfig,
       @NonNull final MysqlSourceMetrics metrics,
       @Min(0) final long leaderEpoch) {
     final String name = configuration.getName();
@@ -74,6 +75,9 @@ public class MysqlSourceFactory {
     SchemaTracker schemaTracker;
 
     if (configuration.isSchemaVersionEnabled()) {
+      Preconditions.checkNotNull(
+          schemaStoreConfig,
+          "MySQL schema version is enabled but mysql-schema-store is not set in config");
       final DBI schemaStoreDBI =
           MysqlSchemaUtil.createMysqlDBI(
               schemaStoreConfig.getHost(),


### PR DESCRIPTION
2 changes:
1. Make mysql-schema-store optional in config. Schema store is not mandatory to run SpinalTap but current config doesn't allow empty schema store config.
2. Update kafka topic name, use source name instead of hostname, as hostname can change in db migration.

@mangobatao 