### PR TITLE
[spinaltap-mysql] Fix warning in EventOrderValidator

### DIFF
--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/validator/EventOrderValidator.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/validator/EventOrderValidator.java
@@ -29,7 +29,7 @@ public class EventOrderValidator implements Validator<BinlogEvent> {
     long eventId = event.getOffset();
     log.debug("Validating order for event with id {}. {}", eventId, event);
 
-    if (lastSeenId > eventId) {
+    if (eventId > 0 && lastSeenId > eventId) {
       log.warn(
           "Mutation with id {} is out of order and should precede {}. {}",
           eventId,


### PR DESCRIPTION
When binlog client (mysql-binlog-connector) starts reading from an offset that is in the middle of the binlog file, the first two events are `ROTATE` with offset `-57` and `FORMAT_DESCRIPTION` with offset `-119`.
Example: streaming from `mysql-bin-changelog.372113:9407132`:
```
Event type: ROTATE
FilePos: mysql-bin-changelog.372113:-57:0
Event type: FORMAT_DESCRIPTION
FilePos: mysql-bin-changelog.372113:-119:0
Event type: ANONYMOUS_GTID
FilePos: mysql-bin-changelog.372113:9407132:9407197
Event type: QUERY
FilePos: mysql-bin-changelog.372113:9407197:9407283
Event type: TABLE_MAP
FilePos: mysql-bin-changelog.372113:9407283:9407362
Event type: EXT_UPDATE_ROWS
FilePos: mysql-bin-changelog.372113:9407362:9408653
Event type: XID
```
The initial value of `lastSeenId` in `EventOrderValidator` is set to `-1`, so the first two events will trigger warning, which is confusing:
```
WARN com.airbnb.spinaltap.mysql.validator.EventOrderValidator: Mutation with id -119 is out of order and should precede -1. BinlogEvent(tableId=0, serverId=1155235892, binlogFilePos=mysql-bin-changelog.371029:-119:0)
```

As the binlog offsets should be positive, we can ignore the negative offsets in `EventOrderValidator`.


@mangobatao 