### PR TITLE
Various bug fixes and improvements

### DIFF
--- a/gradle/libraries.gradle
+++ b/gradle/libraries.gradle
@@ -23,7 +23,7 @@ ext {
     log4j_slf4j_impl: 'org.apache.logging.log4j:log4j-slf4j-impl:2.9.1',
     lombok: 'org.projectlombok:lombok:1.18.2',
     mokito: 'org.mockito:mockito-all:1.10.19',
-    mysql_binlog_connector: 'com.github.shyiko:mysql-binlog-connector-java:0.13.0',
+    mysql_binlog_connector: 'com.github.shyiko:mysql-binlog-connector-java:0.20.1',
     mysql_connector: 'mysql:mysql-connector-java:5.1.44',
     slf4j: 'org.slf4j:slf4j-api:1.7.25',
     thrift: 'org.apache.thrift:libthrift:0.9.3',

--- a/spinaltap-common/src/main/java/com/airbnb/spinaltap/common/destination/BufferedDestination.java
+++ b/spinaltap-common/src/main/java/com/airbnb/spinaltap/common/destination/BufferedDestination.java
@@ -33,6 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public final class BufferedDestination extends ListenableDestination {
+  @NonNull private final String name;
   @NonNull private final Destination destination;
   @NonNull private final DestinationMetrics metrics;
   @NonNull private final BlockingQueue<List<? extends Mutation<?>>> mutationBuffer;
@@ -40,10 +41,11 @@ public final class BufferedDestination extends ListenableDestination {
   private ExecutorService consumer;
 
   public BufferedDestination(
+      @NonNull final String name,
       @Min(1) final int bufferSize,
       @NonNull final Destination destination,
       @NonNull final DestinationMetrics metrics) {
-    this(destination, metrics, new ArrayBlockingQueue<>(bufferSize, true));
+    this(name, destination, metrics, new ArrayBlockingQueue<>(bufferSize, true));
 
     destination.addListener(
         new Listener() {
@@ -161,7 +163,9 @@ public final class BufferedDestination extends ListenableDestination {
 
       consumer =
           Executors.newSingleThreadExecutor(
-              new ThreadFactoryBuilder().setNameFormat("buffered-destination-consumer").build());
+              new ThreadFactoryBuilder()
+                  .setNameFormat(name + "buffered-destination-consumer")
+                  .build());
 
       consumer.execute(this::execute);
 

--- a/spinaltap-common/src/main/java/com/airbnb/spinaltap/common/destination/BufferedDestination.java
+++ b/spinaltap-common/src/main/java/com/airbnb/spinaltap/common/destination/BufferedDestination.java
@@ -72,8 +72,6 @@ public final class BufferedDestination extends ListenableDestination {
         return;
       }
 
-      Preconditions.checkState(destination.isStarted(), "Destination is not started!");
-
       final Stopwatch stopwatch = Stopwatch.createStarted();
       final Mutation.Metadata metadata = mutations.get(0).getMetadata();
 

--- a/spinaltap-common/src/main/java/com/airbnb/spinaltap/common/destination/DestinationBuilder.java
+++ b/spinaltap-common/src/main/java/com/airbnb/spinaltap/common/destination/DestinationBuilder.java
@@ -24,7 +24,7 @@ public abstract class DestinationBuilder<T> {
   protected String topicNamePrefix = "spinaltap";
   protected boolean largeMessageEnabled = false;
   protected long delaySendMs = 0;
-
+  private String name = "";
   private KeyProvider<Mutation<?>, String> keyProvider;
   private int bufferSize = 0;
   private int poolSize = 0;
@@ -53,6 +53,11 @@ public abstract class DestinationBuilder<T> {
 
   public final DestinationBuilder<T> withBuffer(@Min(0) final int bufferSize) {
     this.bufferSize = bufferSize;
+    return this;
+  }
+
+  public final DestinationBuilder<T> withName(@NonNull final String name) {
+    this.name = name;
     return this;
   }
 
@@ -91,7 +96,7 @@ public abstract class DestinationBuilder<T> {
           }
 
           if (bufferSize > 0) {
-            return new BufferedDestination(bufferSize, destination, metrics);
+            return new BufferedDestination(name, bufferSize, destination, metrics);
           }
 
           return destination;

--- a/spinaltap-common/src/main/java/com/airbnb/spinaltap/common/destination/DestinationPool.java
+++ b/spinaltap-common/src/main/java/com/airbnb/spinaltap/common/destination/DestinationPool.java
@@ -14,6 +14,7 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.AccessLevel;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -32,11 +33,15 @@ public final class DestinationPool extends ListenableDestination {
   @NonNull private final KeyProvider<Mutation<?>, String> keyProvider;
   @NonNull private final List<Destination> destinations;
   @NonNull private final boolean[] isActive;
+  private final AtomicBoolean isErrorNotified = new AtomicBoolean();
 
   private Listener destinationListener =
       new Listener() {
         public void onError(Exception ex) {
-          notifyError(ex);
+          // Only notify once if error occurred in multiple destinations
+          if (isErrorNotified.compareAndSet(false, true)) {
+            notifyError(ex);
+          }
         }
       };
 
@@ -111,6 +116,7 @@ public final class DestinationPool extends ListenableDestination {
   @Override
   public void open() {
     Arrays.fill(isActive, false);
+    isErrorNotified.set(false);
     destinations.parallelStream().forEach(Destination::open);
   }
 

--- a/spinaltap-common/src/main/java/com/airbnb/spinaltap/common/destination/DestinationPool.java
+++ b/spinaltap-common/src/main/java/com/airbnb/spinaltap/common/destination/DestinationPool.java
@@ -9,7 +9,6 @@ import static java.util.stream.Collectors.toList;
 
 import com.airbnb.spinaltap.Mutation;
 import com.airbnb.spinaltap.common.util.KeyProvider;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;

--- a/spinaltap-common/src/main/java/com/airbnb/spinaltap/common/destination/DestinationPool.java
+++ b/spinaltap-common/src/main/java/com/airbnb/spinaltap/common/destination/DestinationPool.java
@@ -115,7 +115,6 @@ public final class DestinationPool extends ListenableDestination {
 
   @Override
   public void open() {
-    Arrays.fill(isActive, false);
     isErrorNotified.set(false);
     destinations.parallelStream().forEach(Destination::open);
   }

--- a/spinaltap-common/src/main/java/com/airbnb/spinaltap/common/pipe/Pipe.java
+++ b/spinaltap-common/src/main/java/com/airbnb/spinaltap/common/pipe/Pipe.java
@@ -9,9 +9,8 @@ import com.airbnb.spinaltap.common.destination.Destination;
 import com.airbnb.spinaltap.common.source.Source;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -37,12 +36,12 @@ public class Pipe {
   private final Destination.Listener destinationListener = new DestinationListener();
 
   /** The checkpoint executor that periodically checkpoints the state of the source. */
-  private ScheduledExecutorService checkpointExecutor;
+  private ExecutorService checkpointExecutor;
 
   /**
    * The keep-alive executor that periodically checks the pipe is alive, and otherwise restarts it.
    */
-  private ScheduledExecutorService keepAliveExecutor;
+  private ExecutorService keepAliveExecutor;
 
   /** @return The name of the pipe. */
   public String getName() {
@@ -72,28 +71,34 @@ public class Pipe {
       log.debug("Keep-alive executor is running");
       return;
     }
-
+    String name = getName() + "-pipe-keep-alive-executor";
     keepAliveExecutor =
-        Executors.newSingleThreadScheduledExecutor(
-            new ThreadFactoryBuilder()
-                .setNameFormat(getName() + "-pipe-keep-alive-executor")
-                .build());
+        Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat(name).build());
 
-    keepAliveExecutor.scheduleAtFixedRate(
+    keepAliveExecutor.execute(
         () -> {
           try {
-            if (isStarted()) {
-              log.info("Pipe {} is alive", getName());
-            } else {
-              open();
-            }
-          } catch (Exception ex) {
-            log.error("Failed to open pipe " + getName(), ex);
+            Thread.sleep(EXECUTOR_DELAY_SECONDS * 1000);
+          } catch (InterruptedException ex) {
+            log.info("{} is interrupted.", name);
           }
-        },
-        EXECUTOR_DELAY_SECONDS,
-        KEEP_ALIVE_PERIOD_SECONDS,
-        TimeUnit.SECONDS);
+          while (!keepAliveExecutor.isShutdown()) {
+            try {
+              if (isStarted()) {
+                log.info("Pipe {} is alive", getName());
+              } else {
+                open();
+              }
+            } catch (Exception ex) {
+              log.error("Failed to open pipe " + getName(), ex);
+            }
+            try {
+              Thread.sleep(KEEP_ALIVE_PERIOD_SECONDS * 1000);
+            } catch (InterruptedException ex) {
+              log.info("{} is interrupted.", name);
+            }
+          }
+        });
   }
 
   private void scheduleCheckpointExecutor() {
@@ -101,24 +106,30 @@ public class Pipe {
       log.debug("Checkpoint executor is running");
       return;
     }
-
+    String name = getName() + "-pipe-checkpoint-executor";
     checkpointExecutor =
-        Executors.newSingleThreadScheduledExecutor(
-            new ThreadFactoryBuilder()
-                .setNameFormat(getName() + "-pipe-checkpoint-executor")
-                .build());
+        Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat(name).build());
 
-    checkpointExecutor.scheduleAtFixedRate(
+    checkpointExecutor.execute(
         () -> {
           try {
-            checkpoint();
-          } catch (Exception ex) {
-            log.error("Failed to checkpoint pipe " + getName(), ex);
+            Thread.sleep(EXECUTOR_DELAY_SECONDS * 1000);
+          } catch (InterruptedException ex) {
+            log.info("{} is interrupted.", name);
           }
-        },
-        EXECUTOR_DELAY_SECONDS,
-        CHECKPOINT_PERIOD_SECONDS,
-        TimeUnit.SECONDS);
+          while (!checkpointExecutor.isShutdown()) {
+            try {
+              checkpoint();
+            } catch (Exception ex) {
+              log.error("Failed to checkpoint pipe " + getName(), ex);
+            }
+            try {
+              Thread.sleep(CHECKPOINT_PERIOD_SECONDS * 1000);
+            } catch (InterruptedException ex) {
+              log.info("{} is interrupted.", name);
+            }
+          }
+        });
   }
 
   /** Stops event streaming for the pipe. */

--- a/spinaltap-common/src/main/java/com/airbnb/spinaltap/common/source/AbstractDataStoreSource.java
+++ b/spinaltap-common/src/main/java/com/airbnb/spinaltap/common/source/AbstractDataStoreSource.java
@@ -32,7 +32,7 @@ public abstract class AbstractDataStoreSource<E extends SourceEvent> extends Abs
   }
 
   @Override
-  protected void start() {
+  protected synchronized void start() {
     processor =
         Executors.newSingleThreadExecutor(
             new ThreadFactoryBuilder().setNameFormat(name + "-source-processor").build());
@@ -59,17 +59,17 @@ public abstract class AbstractDataStoreSource<E extends SourceEvent> extends Abs
   }
 
   @Override
-  public boolean isStarted() {
+  public synchronized boolean isStarted() {
     return started.get() && isRunning();
   }
 
   @Override
-  protected boolean isRunning() {
+  protected synchronized boolean isRunning() {
     return processor != null && !processor.isShutdown();
   }
 
   @Override
-  protected boolean isTerminated() {
+  protected synchronized boolean isTerminated() {
     return processor == null || processor.isTerminated();
   }
 

--- a/spinaltap-common/src/main/java/com/airbnb/spinaltap/common/source/AbstractDataStoreSource.java
+++ b/spinaltap-common/src/main/java/com/airbnb/spinaltap/common/source/AbstractDataStoreSource.java
@@ -5,12 +5,14 @@
 package com.airbnb.spinaltap.common.source;
 
 import com.airbnb.spinaltap.Mutation;
+import com.airbnb.spinaltap.common.util.ConcurrencyUtil;
 import com.airbnb.spinaltap.common.util.Filter;
 import com.airbnb.spinaltap.common.util.Mapper;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 
@@ -51,11 +53,12 @@ public abstract class AbstractDataStoreSource<E extends SourceEvent> extends Abs
 
   @Override
   protected void stop() throws Exception {
-    disconnect();
-
-    if (processor != null) {
-      processor.shutdownNow();
+    if (isRunning()) {
+      synchronized (this) {
+        ConcurrencyUtil.shutdownGracefully(processor, 2, TimeUnit.SECONDS);
+      }
     }
+    disconnect();
   }
 
   @Override

--- a/spinaltap-common/src/test/java/com/airbnb/spinaltap/common/destination/BufferedDestinationTest.java
+++ b/spinaltap-common/src/test/java/com/airbnb/spinaltap/common/destination/BufferedDestinationTest.java
@@ -4,7 +4,6 @@
  */
 package com.airbnb.spinaltap.common.destination;
 
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -29,7 +28,7 @@ public class BufferedDestinationTest {
   private final DestinationMetrics metrics = mock(DestinationMetrics.class);
 
   private BufferedDestination bufferedDestination =
-      new BufferedDestination(10, destination, metrics);
+      new BufferedDestination("test", 10, destination, metrics);
 
   @Before
   public void setUp() throws Exception {
@@ -54,7 +53,7 @@ public class BufferedDestinationTest {
 
     bufferedDestination.close();
 
-    assertFalse(bufferedDestination.isStarted());
+    verify(destination).close();
   }
 
   @Test

--- a/spinaltap-common/src/test/java/com/airbnb/spinaltap/common/pipe/PipeTest.java
+++ b/spinaltap-common/src/test/java/com/airbnb/spinaltap/common/pipe/PipeTest.java
@@ -36,6 +36,9 @@ public class PipeTest {
 
     pipe.start();
 
+    when(source.isStarted()).thenReturn(true);
+    when(destination.isStarted()).thenReturn(true);
+
     verify(source, times(1)).addListener(any(Source.Listener.class));
     verify(source, times(1)).open();
 

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/MysqlPipeFactory.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/MysqlPipeFactory.java
@@ -128,6 +128,7 @@ public final class MysqlPipeFactory extends AbstractPipeFactory<MysqlConfigurati
                 "destination builder is not found for %s.", destinationConfiguration.getType()));
     return destinationBuilderSupplier
         .get()
+        .withName(sourceConfiguration.getName())
         .withTopicNamePrefix(MysqlConfiguration.MYSQL_TOPICS.get(sourceConfiguration.getHostRole()))
         .withMapper(ThriftMutationMapper.create(getHostName()))
         .withMetrics(new MysqlDestinationMetrics(sourceConfiguration.getName(), metricRegistry))

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/MysqlSource.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/MysqlSource.java
@@ -172,6 +172,7 @@ public abstract class MysqlSource extends AbstractDataStoreSource<BinlogEvent> {
     if (ex instanceof InvalidBinlogPositionException) {
       resetToLastValidState();
     }
+    throw new RuntimeException(ex);
   }
 
   /** Checkpoints the {@link SourceState} for the source at the given {@link Mutation} position. */

--- a/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/MysqlSourceTest.java
+++ b/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/MysqlSourceTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -170,11 +171,20 @@ public class MysqlSourceTest {
 
     source.addListener(listener);
     source.setPosition(null);
+    try {
+      source.onCommunicationError(new RuntimeException());
+      fail("Should not reach here");
+    } catch (Exception ex) {
 
-    source.onCommunicationError(new RuntimeException());
+    }
     assertNull(source.getLastSavedState().get());
 
-    source.onCommunicationError(new InvalidBinlogPositionException(""));
+    try {
+      source.onCommunicationError(new InvalidBinlogPositionException(""));
+      fail("Should not reach here");
+    } catch (Exception ex) {
+
+    }
     assertEquals(
         MysqlSource.EARLIEST_BINLOG_POS, source.getLastSavedState().get().getLastPosition());
   }

--- a/spinaltap-standalone/build.gradle
+++ b/spinaltap-standalone/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id "com.github.johnrengelman.shadow" version "2.0.2"
+  id "com.github.johnrengelman.shadow" version "5.0.0"
 }
 
 dependencies {


### PR DESCRIPTION
This PR addresses the following bug fixes and improvements:

### Bug fixes
#### [Destination] Do not clear `isActive` flag on destination pool reopen. 

`isActive` flag is used to indicate whether a `destination` is ever used in the pool. When committing checkpoints, the logic in `getLastPublishedMutation()` is first checking `isActive==true && lastPublishedMutation == null` destinations, then return the minimum offset of destinations where `lastPublishedMutation != null`. 

Imagine a scenario that the first mutation in a stream failed to publish (for example, in destinations[0]) but the following mutations were published successfully. In this case, `getLastPublishedMutation()` is supposed to return `null` because the first mutation was not published successfully. The pool will be closed and reopened, all `isActive` flags are cleared and set to false. However, at this time, calling `getLastPublishedMutation()` still returns an offset from other `destinations` which contains successfully published mutations. SpinalTap will never publish the failed mutation again. A simple fix is to keep `isActive` flag status on destination pool reopen, so correct offset will be returned on checkpointing.

#### [Source] Shutdown source-processor executor before disconnect to avoid deadlock

In source, a single-thread executor `source-processor` is used to read events from binary logs, transform into SpinalTap mutations, and push mutations into a `BlockingQueue`. When source fails, the error handler callback will disconnect from MySQL and shutdown the executor. When destination fails, the previous design is to close destination in pipe and let source detect the closure of destination and close source itself. However, this design has a problem: When destination is closed due to publish failure, but at this time source doesn't receive new events, it is not aware of the failure on destination. `keep-alive` thread will bring back the destination, and the failing mutation will never be published again.

So it is better to close both source and destination (the entire pipe) on destination failure. However, destination error handler is triggered in destination thread (`buffered-destination`), if we try to disconnect MySQL connection in this thread, deadlock may occur, because `source-processor` thread may be blocked at pushing mutations into the `BlockingQueue`. Therefore, before disconnecting MySQL connection, we shutdown the executor, which will trigger an interrupt to the `source-processor` thread to avoid deadlock.

#### [Pipe] Close pipe on error in error-handling executor

Under certain circumstances, source and destination may hit error at the same time and both try to close pipe. `Pipe::close()` is defined as `synchronized`(to make it mutual exclusive with `Pipe::open()`), if destination thread enters `Pipe::close()` first, it will try to close the MySQL connection and wait for the source thread to release a lock. However, source thread is waiting for destination thread to finish executing `Pipe::close()`, deadlock occurs here.

A hacky solution is to executing `Pipe::close()` in a separate single-thread executor when failure happens in either source or destination. Since it is a single-thread executor, and `Pipe::close()` is designed to be run idempotently, even source and destination try to execute `Pipe::close()` concurrently, there won't be deadlock.

#### [Source] Throw exception on MySQL communication failure

We did not throw exception on MySQL communication failure, this may turn the source into a state where it stopped processing binary log events but still `open`.

### Improvements
#### [destination] Add source name to thread/executor name for better visibility in debugging
#### Make source/destination executorService operation synchronized

`isRunning()`, `isStarted()`, `isTerminated()` and executor creation block should be `synchronized` in case they are executed concurrently.

#### [Destination] Only notify error once in destination pool

A destination pool may contain multiple destinations. When any of the destinations hit error, a error handling callback function will be called. In current design, if multiple destinations in the pool hit error, the error handling function will be called by each of the erred destination, resulting the destination pool to be closed multiple times. Since closing the destination pool closes all its destinations, it is okay to trigger the error handling callback just once to close the pool.

#### [Pipe] Do not use `ScheduledExecutorService` for keepalive/checkpoint

We use `ScheduledExecutorService` to do keepalive check every 5 seconds and commit checkpoints every 60 seconds. However, if the task ran more than 5s/60s, the same task will run again immediately.  It is better to use a `SingleThreadExecutor` and add sleeps inside.

Reviewers: @mangobatao 