### PR TITLE
Handle more cases in MySQL DDL processing 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 sudo: true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
 language: java
 
-jdk:
-  - openjdk8
+dist: bionic
 
 sudo: true
 
 before_install:
   - sudo apt-get -qq update
-  - sudo apt-get install -y automake bison flex g++ git libboost-all-dev libevent-dev libssl-dev libtool make pkg-config
+  - sudo apt-get install -y automake bison flex g++ git libboost-all-dev libevent-dev libssl1.0-dev libtool make pkg-config openjdk-8-jdk
   - ./install-thrift-0.9.3.sh
+  - wget https://raw.githubusercontent.com/michaelklishin/jdk_switcher/master/jdk_switcher.sh
+  - source jdk_switcher.sh
+  - jdk_switcher use openjdk8
 
 install:
   - ./gradlew spotlessCheck

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ subprojects {
   spotless {
     enforceCheck = false
     java {
-      licenseHeader '/** Copyright $YEAR Airbnb. Licensed under Apache-2.0. See License in the project root for license information. */'
+      licenseHeader '/** Copyright 2019 Airbnb. Licensed under Apache-2.0. See License in the project root for license information. */'
       googleJavaFormat('1.4')
     }
   }

--- a/install-thrift-0.9.3.sh
+++ b/install-thrift-0.9.3.sh
@@ -3,7 +3,7 @@ set -ex
 wget http://archive.apache.org/dist/thrift/0.9.3/thrift-0.9.3.tar.gz
 tar xzf thrift-0.9.3.tar.gz
 cd thrift-0.9.3
-sed -i -e 's#mvn.repo=http://repo1.maven.org/maven2#mvn.repo=https://repo1.maven.org/maven2#g' ./lib/java/build.properties ./lib/java/build.properties-e
 ./configure --without-qt4 --without-qt5 --without-csharp --without-erlang --without-nodejs --without-lua --without-python --without-perl --without-php --without-php_extension --without-dart --without-ruby --without-haskell --without-go --without-haxe --without-d
+sed -i -e 's#mvn.repo=http://repo1.maven.org/maven2#mvn.repo=https://repo1.maven.org/maven2#g' ./lib/java/build.properties
 make
 sudo make install

--- a/install-thrift-0.9.3.sh
+++ b/install-thrift-0.9.3.sh
@@ -3,6 +3,7 @@ set -ex
 wget http://archive.apache.org/dist/thrift/0.9.3/thrift-0.9.3.tar.gz
 tar xzf thrift-0.9.3.tar.gz
 cd thrift-0.9.3
+sed -i -e 's/mvn.repo=http/mvn.repo=https/g' ./lib/java/build.properties
 ./configure --without-qt4 --without-qt5 --without-csharp --without-erlang --without-nodejs --without-lua --without-python --without-perl --without-php --without-php_extension --without-dart --without-ruby --without-haskell --without-go --without-haxe --without-d
 make
 sudo make install

--- a/install-thrift-0.9.3.sh
+++ b/install-thrift-0.9.3.sh
@@ -3,7 +3,7 @@ set -ex
 wget http://archive.apache.org/dist/thrift/0.9.3/thrift-0.9.3.tar.gz
 tar xzf thrift-0.9.3.tar.gz
 cd thrift-0.9.3
-sed -i -e 's/mvn.repo=http/mvn.repo=https/g' ./lib/java/build.properties
+sed -i -e 's#mvn.repo=http://repo1.maven.org/maven2#mvn.repo=https://repo1.maven.org/maven2#g' ./lib/java/build.properties ./lib/java/build.properties-e
 ./configure --without-qt4 --without-qt5 --without-csharp --without-erlang --without-nodejs --without-lua --without-python --without-perl --without-php --without-php_extension --without-dart --without-ruby --without-haskell --without-go --without-haxe --without-d
 make
 sudo make install

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/binlog_connector/BinaryLogConnectorEventMapper.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/binlog_connector/BinaryLogConnectorEventMapper.java
@@ -82,7 +82,7 @@ public final class BinaryLogConnectorEventMapper {
                   queryData
                       .getSql()
                       // https://dev.mysql.com/doc/refman/5.7/en/comments.html
-                      // Remove MySQL-specific comments (/*! ... */ and /*!50110 ... */) which
+                      // Replace MySQL-specific comments (/*! ... */ and /*!50110 ... */) which
                       // are actually executed
                       .replaceAll("/\\*!(?:\\d{5})?(.*?)\\*/", "$1")
                       // Remove line comments and block comments along with newlines
@@ -90,7 +90,8 @@ public final class BinaryLogConnectorEventMapper {
                       .replaceAll(
                           "((?:--\\s+|#).*?)?(?:\\r|\\n)|/\\*[^*]*\\*+(?:[^/*][^*]*\\*+)*/", " ")
                       // Remove extra spaces
-                      .replaceAll("\\s+", " ")));
+                      .replaceAll("\\s+", " ")
+                      .replaceAll("^\\s+", "")));
         case FORMAT_DESCRIPTION:
           return Optional.of(new StartEvent(serverId, timestamp, position));
         default:

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/binlog_connector/BinaryLogConnectorEventMapper.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/binlog_connector/BinaryLogConnectorEventMapper.java
@@ -78,20 +78,19 @@ public final class BinaryLogConnectorEventMapper {
                   timestamp,
                   position,
                   queryData.getDatabase(),
-                  // Remove newline and comments
-                  // Note: This does not handle comments in quotes (e.g. '# comments')
                   queryData
                       .getSql()
                       // https://dev.mysql.com/doc/refman/5.7/en/comments.html
                       // Replace MySQL-specific comments (/*! ... */ and /*!50110 ... */) which
                       // are actually executed
                       .replaceAll("/\\*!(?:\\d{5})?(.*?)\\*/", "$1")
-                      // Remove line comments and block comments along with newlines
+                      // Remove block comments
                       // https://stackoverflow.com/questions/13014947/regex-to-match-a-c-style-multiline-comment
-                      .replaceAll(
-                          "((?:--\\s+|#).*?)?(?:\\r|\\n)|/\\*[^*]*\\*+(?:[^/*][^*]*\\*+)*/", " ")
+                      // line comments and newlines are kept
+                      // Note: This does not handle comments in quotes
+                      .replaceAll("/\\*[^*]*\\*+(?:[^/*][^*]*\\*+)*/", " ")
                       // Remove extra spaces
-                      .replaceAll("\\s+", " ")
+                      .replaceAll("\\h+", " ")
                       .replaceAll("^\\s+", "")));
         case FORMAT_DESCRIPTION:
           return Optional.of(new StartEvent(serverId, timestamp, position));

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/binlog_connector/BinaryLogConnectorEventMapper.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/binlog_connector/BinaryLogConnectorEventMapper.java
@@ -79,6 +79,7 @@ public final class BinaryLogConnectorEventMapper {
                   position,
                   queryData.getDatabase(),
                   // Remove newline and comments
+                  // Note: This does not handle comments in quotes (e.g. '# comments')
                   queryData
                       .getSql()
                       // https://dev.mysql.com/doc/refman/5.7/en/comments.html

--- a/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/binlog_connector/BinaryLogConnectorEventMapperTest.java
+++ b/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/binlog_connector/BinaryLogConnectorEventMapperTest.java
@@ -180,28 +180,6 @@ public class BinaryLogConnectorEventMapperTest {
   }
 
   @Test
-  public void testQueryEventWithLineSQLComments() {
-    String sql_with_line_comments =
-        "-- I am a line comment\n"
-            + "CREATE #I am another line comment \n"
-            + "TABLE t1\n"
-            + "(id bigint(20)) -- line comment\n"
-            + " ENGINE=InnoDB";
-    eventHeader.setEventType(EventType.QUERY);
-    QueryEventData eventData = new QueryEventData();
-    eventData.setDatabase(DATABASE);
-    eventData.setSql(sql_with_line_comments);
-
-    Optional<BinlogEvent> binlogEvent =
-        BinaryLogConnectorEventMapper.INSTANCE.map(
-            new Event(eventHeader, eventData), BINLOG_FILE_POS);
-    assertTrue(binlogEvent.isPresent());
-    String expected_sql = "CREATE TABLE t1 (id bigint(20)) ENGINE=InnoDB";
-    String stripped_sql = ((QueryEvent) (binlogEvent.get())).getSql();
-    assertEquals(expected_sql, stripped_sql);
-  }
-
-  @Test
   public void testQueryEventWithBlockSQLComments() {
     String sql_with_block_comments =
         "CREATE/* ! COMMENTS ! */UNIQUE /* ANOTHER COMMENTS ! */INDEX unique_index\n"
@@ -221,7 +199,8 @@ public class BinaryLogConnectorEventMapperTest {
         BinaryLogConnectorEventMapper.INSTANCE.map(
             new Event(eventHeader, eventData), BINLOG_FILE_POS);
     assertTrue(binlogEvent.isPresent());
-    String expected_sql = "CREATE UNIQUE INDEX unique_index ON `my_db`.`my_table` (`col1`, `col2`)";
+    String expected_sql =
+        "CREATE UNIQUE INDEX unique_index\nON `my_db`.`my_table` (`col1`, `col2`)";
     String stripped_sql = ((QueryEvent) (binlogEvent.get())).getSql();
     assertEquals(expected_sql, stripped_sql);
 
@@ -231,7 +210,7 @@ public class BinaryLogConnectorEventMapperTest {
             new Event(eventHeader, eventData), BINLOG_FILE_POS);
     assertTrue(binlogEvent.isPresent());
     stripped_sql = ((QueryEvent) (binlogEvent.get())).getSql();
-    expected_sql = "CREATE UNIQUE INDEX ON `my_db`.`my_table` (`col1`, `col2`)";
+    expected_sql = "CREATE UNIQUE \nINDEX ON `my_db`.`my_table` (`col1`, `col2`)";
     assertEquals(expected_sql, stripped_sql);
   }
 

--- a/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/binlog_connector/BinaryLogConnectorEventMapperTest.java
+++ b/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/binlog_connector/BinaryLogConnectorEventMapperTest.java
@@ -196,7 +196,7 @@ public class BinaryLogConnectorEventMapperTest {
         BinaryLogConnectorEventMapper.INSTANCE.map(
             new Event(eventHeader, eventData), BINLOG_FILE_POS);
     assertTrue(binlogEvent.isPresent());
-    String expected_sql = " CREATE TABLE t1 (id bigint(20)) ENGINE=InnoDB";
+    String expected_sql = "CREATE TABLE t1 (id bigint(20)) ENGINE=InnoDB";
     String stripped_sql = ((QueryEvent) (binlogEvent.get())).getSql();
     assertEquals(expected_sql, stripped_sql);
   }


### PR DESCRIPTION
Some DDL processing failed because we removed newlines and made all line comments (-- ...and # ...) invalid. 
This PR tries to fix the issue by keeping the newlines and also replacing the MySQL-specific comments mentioned in https://dev.mysql.com/doc/refman/5.7/en/comments.html

Note: This PR does not consider comments in quotes. (e.g. parsing `CREATE TABLE t1 (c1 TEXT DEFAULT "/* ... */")` may cause unexpected behavior)

@mangobatao 