### PR TITLE
GTID Support - 1st PR 

### DIFF
--- a/spinaltap-model/build.gradle
+++ b/spinaltap-model/build.gradle
@@ -6,6 +6,7 @@ dependencies {
   compile libraries.apache_commons_lang
   compile libraries.guava
   compile libraries.jackson_annotations
+  compile libraries.jackson_databind
   compile libraries.slf4j
   compile libraries.thrift
   compileOnly libraries.lombok

--- a/spinaltap-model/src/main/java/com/airbnb/spinaltap/mysql/BinlogFilePos.java
+++ b/spinaltap-model/src/main/java/com/airbnb/spinaltap/mysql/BinlogFilePos.java
@@ -95,26 +95,30 @@ public class BinlogFilePos implements Comparable<BinlogFilePos>, Serializable {
 
   @Override
   public int compareTo(@NonNull final BinlogFilePos other) {
-    if (this.serverUUID == null
-        || other.serverUUID == null
-        || this.serverUUID.equals(other.serverUUID)
-        || this.gtidSet == null
-        || other.gtidSet == null) {
+    if (canCompareUsingFilePosition(this, other)) {
       return getFileNumber() != other.getFileNumber()
           ? Long.compare(getFileNumber(), other.getFileNumber())
           : Long.compare(getPosition(), other.getPosition());
     }
 
-    // Compare GTID
-    GtidSet thisGtidSet = this.gtidSet;
-    GtidSet otherGtidSet = other.gtidSet;
-    if (thisGtidSet.equals(otherGtidSet)) {
+    if (this.gtidSet.equals(other.gtidSet)) {
       return 0;
     }
-    if (thisGtidSet.isContainedWithin(otherGtidSet)) {
+    if (this.gtidSet.isContainedWithin(other.gtidSet)) {
       return -1;
     }
     return 1;
+  }
+
+  /** Check if two BinlogFilePos are from the same source MySQL server */
+  private static boolean isFromSameSource(BinlogFilePos pos1, BinlogFilePos pos2) {
+    return pos1.getServerUUID() != null
+        && pos1.getServerUUID().equalsIgnoreCase(pos2.getServerUUID());
+  }
+
+  /** Whether we can compare two BinlogFilePos using Binlog file position (without GTIDSet) */
+  public static boolean canCompareUsingFilePosition(BinlogFilePos pos1, BinlogFilePos pos2) {
+    return isFromSameSource(pos1, pos2) || pos1.getGtidSet() == null || pos2.getGtidSet() == null;
   }
 
   public static Builder builder() {

--- a/spinaltap-model/src/main/java/com/airbnb/spinaltap/mysql/BinlogFilePos.java
+++ b/spinaltap-model/src/main/java/com/airbnb/spinaltap/mysql/BinlogFilePos.java
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.google.common.base.Splitter;
 import java.io.Serializable;
 import java.util.Iterator;
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,7 +21,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Getter
 @EqualsAndHashCode
-@AllArgsConstructor
 @NoArgsConstructor
 @JsonDeserialize(builder = BinlogFilePos.Builder.class)
 public class BinlogFilePos implements Comparable<BinlogFilePos>, Serializable {
@@ -48,6 +46,17 @@ public class BinlogFilePos implements Comparable<BinlogFilePos>, Serializable {
 
   public BinlogFilePos(long fileNumber, long position, long nextPosition) {
     this(String.format("%s.%06d", DEFAULT_BINLOG_FILE_NAME, fileNumber), position, nextPosition);
+  }
+
+  public BinlogFilePos(
+      String fileName, long position, long nextPosition, String gtidSet, String serverUUID) {
+    this.fileName = fileName;
+    this.position = position;
+    this.nextPosition = nextPosition;
+    this.serverUUID = serverUUID;
+    if (gtidSet != null) {
+      this.gtidSet = new GtidSet(gtidSet);
+    }
   }
 
   public BinlogFilePos(String fileName, long position, long nextPosition) {
@@ -108,7 +117,7 @@ public class BinlogFilePos implements Comparable<BinlogFilePos>, Serializable {
     return 1;
   }
 
-  public Builder builder() {
+  public static Builder builder() {
     return new Builder();
   }
 
@@ -118,7 +127,7 @@ public class BinlogFilePos implements Comparable<BinlogFilePos>, Serializable {
     private String fileName;
     private long position;
     private long nextPosition;
-    private GtidSet gtidSet;
+    private String gtidSet;
     private String serverUUID;
 
     public Builder withFileName(String fileName) {
@@ -137,9 +146,7 @@ public class BinlogFilePos implements Comparable<BinlogFilePos>, Serializable {
     }
 
     public Builder withGtidSet(String gtidSet) {
-      if (gtidSet != null) {
-        this.gtidSet = new GtidSet(gtidSet);
-      }
+      this.gtidSet = gtidSet;
       return this;
     }
 

--- a/spinaltap-model/src/main/java/com/airbnb/spinaltap/mysql/BinlogFilePos.java
+++ b/spinaltap-model/src/main/java/com/airbnb/spinaltap/mysql/BinlogFilePos.java
@@ -95,7 +95,7 @@ public class BinlogFilePos implements Comparable<BinlogFilePos>, Serializable {
 
   @Override
   public int compareTo(@NonNull final BinlogFilePos other) {
-    if (canCompareUsingFilePosition(this, other)) {
+    if (shouldCompareUsingFilePosition(this, other)) {
       return getFileNumber() != other.getFileNumber()
           ? Long.compare(getFileNumber(), other.getFileNumber())
           : Long.compare(getPosition(), other.getPosition());
@@ -117,7 +117,7 @@ public class BinlogFilePos implements Comparable<BinlogFilePos>, Serializable {
   }
 
   /** Whether we can compare two BinlogFilePos using Binlog file position (without GTIDSet) */
-  public static boolean canCompareUsingFilePosition(BinlogFilePos pos1, BinlogFilePos pos2) {
+  public static boolean shouldCompareUsingFilePosition(BinlogFilePos pos1, BinlogFilePos pos2) {
     return isFromSameSource(pos1, pos2) || pos1.getGtidSet() == null || pos2.getGtidSet() == null;
   }
 

--- a/spinaltap-model/src/main/java/com/airbnb/spinaltap/mysql/BinlogFilePos.java
+++ b/spinaltap-model/src/main/java/com/airbnb/spinaltap/mysql/BinlogFilePos.java
@@ -6,6 +6,8 @@ package com.airbnb.spinaltap.mysql;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonPOJOBuilder;
 import com.google.common.base.Splitter;
 import java.io.Serializable;
 import java.util.Iterator;
@@ -22,6 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 @EqualsAndHashCode
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonDeserialize(builder = BinlogFilePos.Builder.class)
 public class BinlogFilePos implements Comparable<BinlogFilePos>, Serializable {
   private static final long serialVersionUID = 1549638989059430876L;
 
@@ -32,6 +35,8 @@ public class BinlogFilePos implements Comparable<BinlogFilePos>, Serializable {
   @JsonProperty private String fileName;
   @JsonProperty private long position;
   @JsonProperty private long nextPosition;
+  @JsonProperty private GtidSet gtidSet;
+  @JsonProperty private String serverUUID;
 
   public BinlogFilePos(long fileNumber) {
     this(fileNumber, 4L, 4L);
@@ -43,6 +48,10 @@ public class BinlogFilePos implements Comparable<BinlogFilePos>, Serializable {
 
   public BinlogFilePos(long fileNumber, long position, long nextPosition) {
     this(String.format("%s.%06d", DEFAULT_BINLOG_FILE_NAME, fileNumber), position, nextPosition);
+  }
+
+  public BinlogFilePos(String fileName, long position, long nextPosition) {
+    this(fileName, position, nextPosition, null, null);
   }
 
   public static BinlogFilePos fromString(@NonNull final String position) {
@@ -77,8 +86,70 @@ public class BinlogFilePos implements Comparable<BinlogFilePos>, Serializable {
 
   @Override
   public int compareTo(@NonNull final BinlogFilePos other) {
-    return getFileNumber() != other.getFileNumber()
-        ? Long.compare(getFileNumber(), other.getFileNumber())
-        : Long.compare(getPosition(), other.getPosition());
+    if (this.serverUUID == null
+        || other.serverUUID == null
+        || this.serverUUID.equals(other.serverUUID)
+        || this.gtidSet == null
+        || other.gtidSet == null) {
+      return getFileNumber() != other.getFileNumber()
+          ? Long.compare(getFileNumber(), other.getFileNumber())
+          : Long.compare(getPosition(), other.getPosition());
+    }
+
+    // Compare GTID
+    GtidSet thisGtidSet = this.gtidSet;
+    GtidSet otherGtidSet = other.gtidSet;
+    if (thisGtidSet.equals(otherGtidSet)) {
+      return 0;
+    }
+    if (thisGtidSet.isContainedWithin(otherGtidSet)) {
+      return -1;
+    }
+    return 1;
+  }
+
+  public Builder builder() {
+    return new Builder();
+  }
+
+  @JsonPOJOBuilder
+  @NoArgsConstructor
+  public static class Builder {
+    private String fileName;
+    private long position;
+    private long nextPosition;
+    private GtidSet gtidSet;
+    private String serverUUID;
+
+    public Builder withFileName(String fileName) {
+      this.fileName = fileName;
+      return this;
+    }
+
+    public Builder withPosition(long position) {
+      this.position = position;
+      return this;
+    }
+
+    public Builder withNextPosition(long nextPosition) {
+      this.nextPosition = nextPosition;
+      return this;
+    }
+
+    public Builder withGtidSet(String gtidSet) {
+      if (gtidSet != null) {
+        this.gtidSet = new GtidSet(gtidSet);
+      }
+      return this;
+    }
+
+    public Builder withServerUUID(String serverUUID) {
+      this.serverUUID = serverUUID;
+      return this;
+    }
+
+    public BinlogFilePos build() {
+      return new BinlogFilePos(fileName, position, nextPosition, gtidSet, serverUUID);
+    }
   }
 }

--- a/spinaltap-model/src/main/java/com/airbnb/spinaltap/mysql/GtidSet.java
+++ b/spinaltap-model/src/main/java/com/airbnb/spinaltap/mysql/GtidSet.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright 2019 Airbnb. Licensed under Apache-2.0. See License in the project root for license
+ * information.
+ */
+package com.airbnb.spinaltap.mysql;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.google.common.base.Joiner;
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Value;
+
+/** This is an improvement of com.github.shyiko.mysql.binlog.GtidSet */
+@EqualsAndHashCode
+public class GtidSet {
+  private static final Splitter COMMA_SPLITTER = Splitter.on(',');
+  private static final Splitter COLUMN_SPLITTER = Splitter.on(':');
+  private static final Splitter DASH_SPLITTER = Splitter.on('-');
+  private static final Joiner COMMA_JOINER = Joiner.on(',');
+  private static final Joiner COLUMN_JOINER = Joiner.on(':');
+
+  // Use sorted map here so we can have a consistent GTID representation
+  private final Map<String, UUIDSet> map = new TreeMap<>();
+
+  public GtidSet(String gtidSetString) {
+    if (Strings.isNullOrEmpty(gtidSetString)) {
+      return;
+    }
+    gtidSetString = gtidSetString.replaceAll("\n", "").replaceAll("\r", "");
+    for (String uuidSet : COMMA_SPLITTER.split(gtidSetString)) {
+      Iterator<String> uuidSetIter = COLUMN_SPLITTER.split(uuidSet).iterator();
+      if (uuidSetIter.hasNext()) {
+        String uuid = uuidSetIter.next();
+        List<Interval> intervals = new LinkedList<>();
+        while (uuidSetIter.hasNext()) {
+          Iterator<String> intervalIter = DASH_SPLITTER.split(uuidSetIter.next()).iterator();
+          if (intervalIter.hasNext()) {
+            long start = Long.parseLong(intervalIter.next());
+            long end = intervalIter.hasNext() ? Long.parseLong(intervalIter.next()) : start;
+            intervals.add(new Interval(start, end));
+          }
+        }
+        if (intervals.size() > 0) {
+          map.put(uuid, new UUIDSet(uuid, intervals));
+        }
+      }
+    }
+  }
+
+  public boolean isContainedWithin(GtidSet other) {
+    if (other == null) {
+      return false;
+    }
+    if (this.equals(other)) {
+      return true;
+    }
+
+    for (UUIDSet uuidSet : map.values()) {
+      UUIDSet thatSet = other.map.get(uuidSet.getUuid());
+      if (!uuidSet.isContainedWithin(thatSet)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  @JsonValue
+  public String toString() {
+    return COMMA_JOINER.join(map.values());
+  }
+
+  @Getter
+  @EqualsAndHashCode
+  public static final class UUIDSet {
+    private final String uuid;
+    private final List<Interval> intervals;
+
+    public UUIDSet(String uuid, List<Interval> intervals) {
+      this.uuid = uuid.toLowerCase();
+      this.intervals = intervals;
+
+      // Collapse intervals if possible
+      Collections.sort(this.intervals);
+      for (int i = intervals.size() - 1; i > 0; i--) {
+        Interval before = this.intervals.get(i - 1);
+        Interval after = this.intervals.get(i);
+        if (after.getStart() <= before.getEnd() + 1) {
+          if (after.getEnd() > before.getEnd()) {
+            this.intervals.set(i - 1, new Interval(before.getStart(), after.getEnd()));
+          }
+          this.intervals.remove(i);
+        }
+      }
+    }
+
+    public boolean isContainedWithin(UUIDSet other) {
+      if (other == null) {
+        return false;
+      }
+      if (!this.uuid.equalsIgnoreCase(other.uuid)) {
+        return false;
+      }
+      if (this.intervals.isEmpty()) {
+        return true;
+      }
+      if (other.intervals.isEmpty()) {
+        return false;
+      }
+
+      // every interval in this must be within an interval of the other ...
+      for (Interval thisInterval : this.intervals) {
+        boolean found = false;
+        for (Interval otherInterval : other.intervals) {
+          if (thisInterval.isContainedWithin(otherInterval)) {
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          return false; // didn't find a match
+        }
+      }
+      return true;
+    }
+
+    @Override
+    public String toString() {
+      return uuid + ":" + COLUMN_JOINER.join(intervals);
+    }
+  }
+
+  @Value
+  public static class Interval implements Comparable<Interval> {
+    long start, end;
+
+    public boolean isContainedWithin(Interval other) {
+      if (other == this) {
+        return true;
+      }
+      if (other == null) {
+        return false;
+      }
+      return this.start >= other.start && this.end <= other.end;
+    }
+
+    @Override
+    public String toString() {
+      return start + "-" + end;
+    }
+
+    @Override
+    public int compareTo(Interval other) {
+      if (this.start != other.start) {
+        return Long.compare(this.start, other.start);
+      }
+      return Long.compare(this.end, other.end);
+    }
+  }
+}

--- a/spinaltap-model/src/main/java/com/airbnb/spinaltap/mysql/Transaction.java
+++ b/spinaltap-model/src/main/java/com/airbnb/spinaltap/mysql/Transaction.java
@@ -4,12 +4,22 @@
  */
 package com.airbnb.spinaltap.mysql;
 
+import lombok.RequiredArgsConstructor;
 import lombok.Value;
 
 /** Represents a MySQL Transaction boundary in the binlog. */
 @Value
+@RequiredArgsConstructor
 public class Transaction {
   private final long timestamp;
   private final long offset;
   private final BinlogFilePos position;
+  private final String gtid;
+
+  public Transaction(long timestamp, long offset, BinlogFilePos position) {
+    this.timestamp = timestamp;
+    this.offset = offset;
+    this.position = position;
+    this.gtid = null;
+  }
 }

--- a/spinaltap-model/src/main/thrift/com/airbnb/jitney/event/spinaltap/spinaltap_v1.thrift
+++ b/spinaltap-model/src/main/thrift/com/airbnb/jitney/event/spinaltap/spinaltap_v1.thrift
@@ -31,6 +31,11 @@ struct BinlogHeader {
   7: optional i64 leader_epoch,
   8: optional i64 id,
   9: optional i32 event_row_position,
+  10: optional string server_uuid,
+  11: optional string last_transaction_gtid_set,
+  12: optional string begin_transaction_pos,
+  13: optional i64 begin_transaction_timestamp,
+  14: optional string begin_transaction_gtid,
 }
 
 struct Table {

--- a/spinaltap-model/src/test/java/com/airbnb/spinaltap/GtidSetTest.java
+++ b/spinaltap-model/src/test/java/com/airbnb/spinaltap/GtidSetTest.java
@@ -53,6 +53,17 @@ public class GtidSetTest {
   }
 
   @Test
+  public void testMixedCaseServerUUID() {
+    String upperCaseServerUUID1 = SERVER_UUID_1.toUpperCase();
+    GtidSet gtidSet =
+        new GtidSet(
+            String.format(
+                "%s:1-24,%s:25-706,%s:1-23", upperCaseServerUUID1, SERVER_UUID_1, SERVER_UUID_2));
+    assertEquals(
+        new GtidSet(String.format("%s:1-706,%s:1-23", SERVER_UUID_1, SERVER_UUID_2)), gtidSet);
+  }
+
+  @Test
   public void testSubsetOf() {
     GtidSet[] set = {
       new GtidSet(""),

--- a/spinaltap-model/src/test/java/com/airbnb/spinaltap/GtidSetTest.java
+++ b/spinaltap-model/src/test/java/com/airbnb/spinaltap/GtidSetTest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2019 Airbnb. Licensed under Apache-2.0. See License in the project root for license
+ * information.
+ */
+package com.airbnb.spinaltap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import com.airbnb.spinaltap.mysql.GtidSet;
+import org.junit.Test;
+
+public class GtidSetTest {
+  private static final String SERVER_UUID_1 = "665ef2f4-b008-4440-b78c-26ba7ce500e6";
+  private static final String SERVER_UUID_2 = "eeb24231-ff9d-4051-b9b1-bf40bf33b2be";
+
+  @Test
+  public void testEmptySet() {
+    assertEquals(new GtidSet("").toString(), "");
+  }
+
+  @Test
+  public void testEquals() {
+    assertEquals(new GtidSet(""), new GtidSet(""));
+    assertEquals(new GtidSet(""), new GtidSet(null));
+
+    assertEquals(new GtidSet(SERVER_UUID_1 + ":1-888"), new GtidSet(SERVER_UUID_1 + ":1-888"));
+
+    GtidSet gtidSet1 =
+        new GtidSet(String.format("%s:1-1023,%s:1-888", SERVER_UUID_1, SERVER_UUID_2));
+    GtidSet gtidSet2 =
+        new GtidSet(String.format("%s:1-888,%s:1-1023", SERVER_UUID_2, SERVER_UUID_1));
+    assertEquals(gtidSet1, gtidSet2);
+    assertEquals(gtidSet1.toString(), gtidSet2.toString());
+
+    assertNotEquals(
+        new GtidSet(SERVER_UUID_1 + ":1-888"), new GtidSet(SERVER_UUID_1 + ":1-100:102-888"));
+    assertNotEquals(new GtidSet(SERVER_UUID_1 + ":1-888"), new GtidSet(SERVER_UUID_2 + ":1-888"));
+  }
+
+  @Test
+  public void testCollapseIntervals() {
+    GtidSet gtidSet = new GtidSet(SERVER_UUID_1 + ":1-123:124:125-200");
+    assertEquals(gtidSet, new GtidSet(SERVER_UUID_1 + ":1-200"));
+    assertEquals(gtidSet.toString(), SERVER_UUID_1 + ":1-200");
+
+    gtidSet = new GtidSet(SERVER_UUID_1 + ":1-201:202-211:239-244:245-300:400-409");
+    assertEquals(gtidSet, new GtidSet(SERVER_UUID_1 + ":1-211:239-300:400-409"));
+    assertEquals(gtidSet.toString(), SERVER_UUID_1 + ":1-211:239-300:400-409");
+
+    gtidSet = new GtidSet(SERVER_UUID_1 + ":1-200:100-123:40-255:40-100:60-100:280-290:270-279");
+    assertEquals(gtidSet.toString(), SERVER_UUID_1 + ":1-255:270-290");
+  }
+
+  @Test
+  public void testSubsetOf() {
+    GtidSet[] set = {
+      new GtidSet(""),
+      new GtidSet(SERVER_UUID_1 + ":1-191"),
+      new GtidSet(SERVER_UUID_1 + ":192-199"),
+      new GtidSet(SERVER_UUID_1 + ":1-191:192-199"),
+      new GtidSet(SERVER_UUID_1 + ":1-191:193-199"),
+      new GtidSet(SERVER_UUID_1 + ":2-199"),
+      new GtidSet(SERVER_UUID_1 + ":1-200")
+    };
+    byte[][] subsetMatrix = {
+      {1, 1, 1, 1, 1, 1, 1},
+      {0, 1, 0, 1, 1, 0, 1},
+      {0, 0, 1, 1, 0, 1, 1},
+      {0, 0, 0, 1, 0, 0, 1},
+      {0, 0, 0, 1, 1, 0, 1},
+      {0, 0, 0, 1, 0, 1, 1},
+      {0, 0, 0, 0, 0, 0, 1},
+    };
+    for (int i = 0; i < subsetMatrix.length; i++) {
+      byte[] subset = subsetMatrix[i];
+      for (int j = 0; j < subset.length; j++) {
+        assertEquals(set[i].isContainedWithin(set[j]), subset[j] == 1);
+      }
+    }
+  }
+}

--- a/spinaltap-model/src/test/java/com/airbnb/spinaltap/mysql/BinlogFilePosTest.java
+++ b/spinaltap-model/src/test/java/com/airbnb/spinaltap/mysql/BinlogFilePosTest.java
@@ -9,6 +9,9 @@ import static org.junit.Assert.*;
 import org.junit.Test;
 
 public class BinlogFilePosTest {
+  private static final String UUID1 = "07592619-e257-4033-a30f-7fe9fcfbf229";
+  private static final String UUID2 = "4a4ac150-fe5b-4093-a1ef-a8876011adaa";
+
   @Test
   public void testCompare() throws Exception {
     BinlogFilePos first = BinlogFilePos.fromString("mysql-bin-changelog.218:14:6");
@@ -19,6 +22,29 @@ public class BinlogFilePosTest {
     assertTrue(first.compareTo(second) < 0);
     assertTrue(third.compareTo(second) > 0);
     assertTrue(third.compareTo(fourth) == 0);
+  }
+
+  @Test
+  public void testCompareWithGTID() {
+    String gtid1 = UUID1 + ":1-200";
+    String gtid2 = UUID1 + ":1-300";
+    String gtid3 = UUID1 + ":1-200," + UUID2 + ":1-456";
+    BinlogFilePos first =
+        new BinlogFilePos("mysql-bin-changelog.218", 123, 456, new GtidSet(gtid1), UUID1);
+    BinlogFilePos second =
+        new BinlogFilePos("mysql-bin-changelog.218", 456, 789, new GtidSet(gtid2), UUID1);
+    BinlogFilePos third =
+        new BinlogFilePos("mysql-bin-changelog.100", 10, 24, new GtidSet(gtid1), UUID2);
+    BinlogFilePos fourth =
+        new BinlogFilePos("mysql-bin-changelog.100", 20, 24, new GtidSet(gtid3), UUID2);
+
+    // server_uuid matches, compare binlog file number and position
+    assertTrue(first.compareTo(second) < 0);
+
+    // server_uuid doesn't match, compare GTID
+    assertEquals(0, first.compareTo(third));
+    assertTrue(first.compareTo(fourth) < 0);
+    assertTrue(second.compareTo(third) > 0);
   }
 
   @Test

--- a/spinaltap-model/src/test/java/com/airbnb/spinaltap/mysql/BinlogFilePosTest.java
+++ b/spinaltap-model/src/test/java/com/airbnb/spinaltap/mysql/BinlogFilePosTest.java
@@ -29,14 +29,10 @@ public class BinlogFilePosTest {
     String gtid1 = UUID1 + ":1-200";
     String gtid2 = UUID1 + ":1-300";
     String gtid3 = UUID1 + ":1-200," + UUID2 + ":1-456";
-    BinlogFilePos first =
-        new BinlogFilePos("mysql-bin-changelog.218", 123, 456, new GtidSet(gtid1), UUID1);
-    BinlogFilePos second =
-        new BinlogFilePos("mysql-bin-changelog.218", 456, 789, new GtidSet(gtid2), UUID1);
-    BinlogFilePos third =
-        new BinlogFilePos("mysql-bin-changelog.100", 10, 24, new GtidSet(gtid1), UUID2);
-    BinlogFilePos fourth =
-        new BinlogFilePos("mysql-bin-changelog.100", 20, 24, new GtidSet(gtid3), UUID2);
+    BinlogFilePos first = new BinlogFilePos("mysql-bin-changelog.218", 123, 456, gtid1, UUID1);
+    BinlogFilePos second = new BinlogFilePos("mysql-bin-changelog.218", 456, 789, gtid2, UUID1);
+    BinlogFilePos third = new BinlogFilePos("mysql-bin-changelog.100", 10, 24, gtid1, UUID2);
+    BinlogFilePos fourth = new BinlogFilePos("mysql-bin-changelog.100", 20, 24, gtid3, UUID2);
 
     // server_uuid matches, compare binlog file number and position
     assertTrue(first.compareTo(second) < 0);

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/MysqlClient.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/MysqlClient.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2019 Airbnb. Licensed under Apache-2.0. See License in the project root for license
+ * information.
+ */
+package com.airbnb.spinaltap.mysql;
+
+import com.mysql.jdbc.jdbc2.optional.MysqlConnectionPoolDataSource;
+import com.mysql.jdbc.jdbc2.optional.MysqlDataSource;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.extern.slf4j.Slf4j;
+
+/** Represents a MySQL server connection and context with utility functions */
+@Slf4j
+public class MysqlClient {
+  private final String host;
+  private final int port;
+  private final String user;
+  private final String password;
+  private final MysqlDataSource dataSource;
+
+  public MysqlClient(String host, int port, String user, String password) {
+    this.host = host;
+    this.port = port;
+    this.user = user;
+    this.password = password;
+    dataSource = createMysqlDataSource();
+  }
+
+  public BinlogFilePos getMasterStatus() {
+    AtomicReference<BinlogFilePos> binlogFilePos = new AtomicReference<>();
+    String serverUUID = getServerUUID();
+    try {
+      executeQuery(
+          "SHOW MASTER STATUS",
+          rs -> {
+            if (rs.next()) {
+              BinlogFilePos.Builder builder =
+                  BinlogFilePos.builder()
+                      .withServerUUID(getServerUUID())
+                      .withFileName(rs.getString(1))
+                      .withPosition(rs.getLong(2))
+                      .withNextPosition(rs.getLong(2));
+
+              if (rs.getMetaData().getColumnCount() > 4) {
+                builder.withGtidSet(rs.getString(5));
+              }
+
+              binlogFilePos.set(builder.build());
+            }
+          });
+    } catch (SQLException ex) {
+      log.error(String.format("Failed to execute SHOW MASTER STATUS on %s%d", host, port));
+      throw new RuntimeException(ex);
+    }
+    return binlogFilePos.get();
+  }
+
+  public String getServerUUID() {
+    return getGlobalVariableValue("server_uuid");
+  }
+
+  public boolean isGtidModeEnabled() {
+    return !"OFF".equalsIgnoreCase(getGlobalVariableValue("gtid_mode"));
+  }
+
+  public String getGlobalVariableValue(String variableName) {
+    AtomicReference<String> value = new AtomicReference<>();
+    try {
+      executeQuery(
+          String.format("SHOW GLOBAL VARIABLES WHERE Variable_name = '%s'", variableName),
+          rs -> {
+            if (rs.next()) {
+              value.set(rs.getString(2));
+            }
+          });
+    } catch (SQLException ex) {
+      log.error(
+          String.format(
+              "Failed to get global variable value for %s on %s:%d", variableName, host, port));
+      throw new RuntimeException(ex);
+    }
+    return value.get();
+  }
+
+  private MysqlDataSource createMysqlDataSource() {
+    MysqlDataSource dataSource = new MysqlConnectionPoolDataSource();
+
+    dataSource.setUser(user);
+    dataSource.setPassword(password);
+    dataSource.setServerName(host);
+    dataSource.setPort(port);
+    dataSource.setJdbcCompliantTruncation(false);
+    dataSource.setAutoReconnectForConnectionPools(true);
+    return dataSource;
+  }
+
+  public void executeQuery(String sql, ResultSetConsumer resultSetConsumer) throws SQLException {
+    try (Connection conn = dataSource.getConnection()) {
+      try (Statement statement = conn.createStatement()) {
+        try (ResultSet resultSet = statement.executeQuery(sql)) {
+          if (resultSetConsumer != null) {
+            resultSetConsumer.accept(resultSet);
+          }
+        }
+      }
+    }
+  }
+
+  public interface ResultSetConsumer {
+    void accept(ResultSet rs) throws SQLException;
+  }
+}

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/MysqlClient.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/MysqlClient.java
@@ -64,7 +64,7 @@ public class MysqlClient {
   }
 
   public boolean isGtidModeEnabled() {
-    return !"OFF".equalsIgnoreCase(getGlobalVariableValue("gtid_mode"));
+    return "ON".equalsIgnoreCase(getGlobalVariableValue("gtid_mode"));
   }
 
   public String getGlobalVariableValue(String variableName) {

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/MysqlSource.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/MysqlSource.java
@@ -188,7 +188,7 @@ public abstract class MysqlSource extends AbstractDataStoreSource<BinlogEvent> {
     // Make sure we are saving at a higher watermark
     BinlogFilePos mutationPosition = metadata.getFilePos();
     BinlogFilePos savedStatePosition = savedState.getLastPosition();
-    if ((BinlogFilePos.canCompareUsingFilePosition(mutationPosition, savedStatePosition)
+    if ((BinlogFilePos.shouldCompareUsingFilePosition(mutationPosition, savedStatePosition)
             && savedState.getLastOffset() >= metadata.getId())
         || (mutationPosition.getGtidSet() != null
             && mutationPosition.getGtidSet().isContainedWithin(savedStatePosition.getGtidSet()))) {

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/MysqlSource.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/MysqlSource.java
@@ -186,7 +186,12 @@ public abstract class MysqlSource extends AbstractDataStoreSource<BinlogEvent> {
     final MysqlMutationMetadata metadata = ((MysqlMutation) mutation).getMetadata();
 
     // Make sure we are saving at a higher watermark
-    if (savedState.getLastOffset() >= metadata.getId()) {
+    BinlogFilePos mutationPosition = metadata.getFilePos();
+    BinlogFilePos savedStatePosition = savedState.getLastPosition();
+    if ((BinlogFilePos.canCompareUsingFilePosition(mutationPosition, savedStatePosition)
+            && savedState.getLastOffset() >= metadata.getId())
+        || (mutationPosition.getGtidSet() != null
+            && mutationPosition.getGtidSet().isContainedWithin(savedStatePosition.getGtidSet()))) {
       return;
     }
 

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/binlog_connector/BinaryLogConnectorEventMapper.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/binlog_connector/BinaryLogConnectorEventMapper.java
@@ -7,6 +7,7 @@ package com.airbnb.spinaltap.mysql.binlog_connector;
 import com.airbnb.spinaltap.mysql.BinlogFilePos;
 import com.airbnb.spinaltap.mysql.event.BinlogEvent;
 import com.airbnb.spinaltap.mysql.event.DeleteEvent;
+import com.airbnb.spinaltap.mysql.event.GTIDEvent;
 import com.airbnb.spinaltap.mysql.event.QueryEvent;
 import com.airbnb.spinaltap.mysql.event.StartEvent;
 import com.airbnb.spinaltap.mysql.event.TableMapEvent;
@@ -17,6 +18,7 @@ import com.github.shyiko.mysql.binlog.event.DeleteRowsEventData;
 import com.github.shyiko.mysql.binlog.event.Event;
 import com.github.shyiko.mysql.binlog.event.EventHeaderV4;
 import com.github.shyiko.mysql.binlog.event.EventType;
+import com.github.shyiko.mysql.binlog.event.GtidEventData;
 import com.github.shyiko.mysql.binlog.event.QueryEventData;
 import com.github.shyiko.mysql.binlog.event.TableMapEventData;
 import com.github.shyiko.mysql.binlog.event.UpdateRowsEventData;
@@ -70,6 +72,9 @@ public final class BinaryLogConnectorEventMapper {
         case XID:
           final XidEventData xidData = event.getData();
           return Optional.of(new XidEvent(serverId, timestamp, position, xidData.getXid()));
+        case GTID:
+          final GtidEventData gtidEventData = event.getData();
+          return Optional.of(new GTIDEvent(serverId, timestamp, position, gtidEventData.getGtid()));
         case QUERY:
           final QueryEventData queryData = event.getData();
           return Optional.of(

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/config/MysqlSchemaStoreConfiguration.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/config/MysqlSchemaStoreConfiguration.java
@@ -4,14 +4,18 @@
  */
 package com.airbnb.spinaltap.mysql.config;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
 /** Represents the configuration for a {@link com.airbnb.spinaltap.mysql.schema.MysqlSchemaStore} */
 @Data
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class MysqlSchemaStoreConfiguration {
   @NonNull @JsonProperty private String host;
 

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/event/GTIDEvent.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/event/GTIDEvent.java
@@ -1,0 +1,18 @@
+/**
+ * Copyright 2019 Airbnb. Licensed under Apache-2.0. See License in the project root for license
+ * information.
+ */
+package com.airbnb.spinaltap.mysql.event;
+
+import com.airbnb.spinaltap.mysql.BinlogFilePos;
+import lombok.Getter;
+
+@Getter
+public class GTIDEvent extends BinlogEvent {
+  private final String gtid;
+
+  public GTIDEvent(long serverId, long timestamp, BinlogFilePos filePos, String gtid) {
+    super(0, serverId, timestamp, filePos);
+    this.gtid = gtid;
+  }
+}

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/event/filter/DuplicateFilter.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/event/filter/DuplicateFilter.java
@@ -36,7 +36,7 @@ public final class DuplicateFilter extends MysqlEventFilter {
     BinlogFilePos eventBinlogPos = event.getBinlogFilePos();
     BinlogFilePos savedBinlogPos = state.get().getLastPosition();
     // Use the same logic in BinlogFilePos.compareTo() here...
-    if (BinlogFilePos.canCompareUsingFilePosition(eventBinlogPos, savedBinlogPos)) {
+    if (BinlogFilePos.shouldCompareUsingFilePosition(eventBinlogPos, savedBinlogPos)) {
       return event.getOffset() > state.get().getLastOffset();
     }
 

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/event/filter/DuplicateFilter.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/event/filter/DuplicateFilter.java
@@ -5,6 +5,8 @@
 package com.airbnb.spinaltap.mysql.event.filter;
 
 import com.airbnb.spinaltap.common.source.SourceState;
+import com.airbnb.spinaltap.mysql.BinlogFilePos;
+import com.airbnb.spinaltap.mysql.GtidSet;
 import com.airbnb.spinaltap.mysql.event.BinlogEvent;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.NonNull;
@@ -21,6 +23,30 @@ public final class DuplicateFilter extends MysqlEventFilter {
   @NonNull private final AtomicReference<SourceState> state;
 
   public boolean apply(@NonNull final BinlogEvent event) {
-    return !event.isMutation() || event.getOffset() > state.get().getLastOffset();
+    // Only applies to mutation events
+    if (!event.isMutation()) {
+      return true;
+    }
+
+    // We need to tell if position in `event` and in `state` are from the same source
+    // MySQL server, because a failover may have happened and we are currently streaming
+    // from the new master.
+    // If they are from the same source server, we can just use the binlog filename and
+    // position (offset) to tell whether we should skip this event.
+    BinlogFilePos eventBinlogPos = event.getBinlogFilePos();
+    BinlogFilePos savedBinlogPos = state.get().getLastPosition();
+    // Use the same logic in BinlogFilePos.compareTo() here...
+    if (BinlogFilePos.canCompareUsingFilePosition(eventBinlogPos, savedBinlogPos)) {
+      return event.getOffset() > state.get().getLastOffset();
+    }
+
+    // If this point is reached, a master failover might have happened.
+    // We can only use GTIDSet to tell whether this event should be skipped.
+    // We should only skip this event if GTIDSet in event is a "proper subset" of the GTIDSet
+    // in saved state, because it is possible that the last transaction we streamed before the
+    // failover is in the middle of a transaction.
+    GtidSet eventGtidSet = eventBinlogPos.getGtidSet();
+    GtidSet savedGtidSet = savedBinlogPos.getGtidSet();
+    return !eventGtidSet.isContainedWithin(savedGtidSet) && !eventGtidSet.equals(savedGtidSet);
   }
 }

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/event/filter/EventTypeFilter.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/event/filter/EventTypeFilter.java
@@ -6,6 +6,7 @@ package com.airbnb.spinaltap.mysql.event.filter;
 
 import com.airbnb.spinaltap.mysql.event.BinlogEvent;
 import com.airbnb.spinaltap.mysql.event.DeleteEvent;
+import com.airbnb.spinaltap.mysql.event.GTIDEvent;
 import com.airbnb.spinaltap.mysql.event.QueryEvent;
 import com.airbnb.spinaltap.mysql.event.StartEvent;
 import com.airbnb.spinaltap.mysql.event.TableMapEvent;
@@ -32,7 +33,8 @@ final class EventTypeFilter extends MysqlEventFilter {
           DeleteEvent.class,
           XidEvent.class,
           QueryEvent.class,
-          StartEvent.class);
+          StartEvent.class,
+          GTIDEvent.class);
 
   public boolean apply(@NonNull final BinlogEvent event) {
     return WHITELISTED_EVENT_TYPES.contains(event.getClass());

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/event/mapper/GTIDMapper.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/event/mapper/GTIDMapper.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2019 Airbnb. Licensed under Apache-2.0. See License in the project root for license
+ * information.
+ */
+package com.airbnb.spinaltap.mysql.event.mapper;
+
+import com.airbnb.spinaltap.common.util.Mapper;
+import com.airbnb.spinaltap.mysql.event.GTIDEvent;
+import com.airbnb.spinaltap.mysql.mutation.MysqlMutation;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Represents a {@link com.airbnb.spinaltap.common.util.Mapper} that keeps track of {@link
+ * GTIDEvent}s, which will be included in {@link com.airbnb.spinaltap.mysql.Transaction}
+ */
+@RequiredArgsConstructor
+final class GTIDMapper implements Mapper<GTIDEvent, List<MysqlMutation>> {
+  private final AtomicReference<String> gtid;
+
+  @Override
+  public List<MysqlMutation> map(@NonNull final GTIDEvent event) {
+    gtid.set(event.getGtid());
+    return Collections.emptyList();
+  }
+}

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/event/mapper/QueryMapper.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/event/mapper/QueryMapper.java
@@ -35,12 +35,14 @@ final class QueryMapper implements Mapper<QueryEvent, List<MysqlMutation>> {
       Pattern.compile("^(CREATE|DROP)\\s+(DATABASE|SCHEMA)", Pattern.CASE_INSENSITIVE);
 
   private final AtomicReference<Transaction> beginTransaction;
+  private final AtomicReference<String> gtid;
   private final SchemaTracker schemaTracker;
 
   public List<MysqlMutation> map(@NonNull final QueryEvent event) {
     if (isTransactionBegin(event)) {
       beginTransaction.set(
-          new Transaction(event.getTimestamp(), event.getOffset(), event.getBinlogFilePos()));
+          new Transaction(
+              event.getTimestamp(), event.getOffset(), event.getBinlogFilePos(), gtid.get()));
     }
 
     if (isDDLStatement(event)) {

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/event/mapper/XidMapper.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/event/mapper/XidMapper.java
@@ -25,11 +25,13 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 final class XidMapper implements Mapper<XidEvent, List<MysqlMutation>> {
   @NonNull private final AtomicReference<Transaction> endTransaction;
+  @NonNull private final AtomicReference<String> gtid;
   @NonNull private final MysqlSourceMetrics metrics;
 
   public List<MysqlMutation> map(@NonNull final XidEvent event) {
     endTransaction.set(
-        new Transaction(event.getTimestamp(), event.getOffset(), event.getBinlogFilePos()));
+        new Transaction(
+            event.getTimestamp(), event.getOffset(), event.getBinlogFilePos(), gtid.get()));
 
     metrics.transactionReceived();
     return Collections.emptyList();

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/mutation/mapper/ThriftMutationMapper.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/mutation/mapper/ThriftMutationMapper.java
@@ -53,8 +53,17 @@ public abstract class ThriftMutationMapper<T extends MysqlMutation>
     if (metadata.getLastTransaction() != null) {
       header.setLastTransactionPos(metadata.getLastTransaction().getPosition().toString());
       header.setLastTransactionTimestamp(metadata.getLastTransaction().getTimestamp());
+      header.setLastTransactionGtidSet(
+          metadata.getLastTransaction().getPosition().getGtidSet().toString());
     }
 
+    if (metadata.getBeginTransaction() != null) {
+      header.setBeginTransactionPos(metadata.getBeginTransaction().getPosition().toString());
+      header.setBeginTransactionTimestamp(metadata.getBeginTransaction().getTimestamp());
+      header.setBeginTransactionGtid(metadata.getBeginTransaction().getGtid());
+    }
+
+    header.setServerUuid(metadata.getFilePos().getServerUUID());
     header.setLeaderEpoch(metadata.getLeaderEpoch());
     header.setId(metadata.getId());
     header.setEventRowPosition(metadata.getEventRowPosition());

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/mutation/mapper/ThriftMutationMapper.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/mutation/mapper/ThriftMutationMapper.java
@@ -9,6 +9,7 @@ import com.airbnb.jitney.event.spinaltap.v1.Mutation;
 import com.airbnb.spinaltap.common.util.ClassBasedMapper;
 import com.airbnb.spinaltap.common.util.Mapper;
 import com.airbnb.spinaltap.mysql.ColumnSerializationUtil;
+import com.airbnb.spinaltap.mysql.GtidSet;
 import com.airbnb.spinaltap.mysql.mutation.MysqlDeleteMutation;
 import com.airbnb.spinaltap.mysql.mutation.MysqlInsertMutation;
 import com.airbnb.spinaltap.mysql.mutation.MysqlMutation;
@@ -53,8 +54,10 @@ public abstract class ThriftMutationMapper<T extends MysqlMutation>
     if (metadata.getLastTransaction() != null) {
       header.setLastTransactionPos(metadata.getLastTransaction().getPosition().toString());
       header.setLastTransactionTimestamp(metadata.getLastTransaction().getTimestamp());
-      header.setLastTransactionGtidSet(
-          metadata.getLastTransaction().getPosition().getGtidSet().toString());
+      GtidSet gtidSet = metadata.getLastTransaction().getPosition().getGtidSet();
+      if (gtidSet != null) {
+        header.setLastTransactionGtidSet(gtidSet.toString());
+      }
     }
 
     if (metadata.getBeginTransaction() != null) {

--- a/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/MysqlSourceTest.java
+++ b/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/MysqlSourceTest.java
@@ -41,7 +41,8 @@ public class MysqlSourceTest {
 
   private static final long SAVED_OFFSET = 12L;
   private static final long SAVED_TIMESTAMP = 12L;
-  private static final BinlogFilePos BINLOG_FILE_POS = new BinlogFilePos("test.txt", 14, 100);
+  private static final BinlogFilePos BINLOG_FILE_POS =
+      new BinlogFilePos("mysql-binlog.123450", 14, 100);
 
   private final TableCache tableCache = mock(TableCache.class);
   private final MysqlSourceMetrics mysqlMetrics = mock(MysqlSourceMetrics.class);
@@ -152,10 +153,10 @@ public class MysqlSourceTest {
     assertEquals(earliestState, source.getLastSavedState().get());
     assertTrue(stateHistory.isEmpty());
 
-    BinlogFilePos filePos = new BinlogFilePos("test.txt", 18, 156);
+    BinlogFilePos filePos = new BinlogFilePos("mysql-binlog.123450", 18, 156);
     Transaction lastTransaction = new Transaction(0L, 0L, filePos);
     MysqlMutationMetadata metadata =
-        new MysqlMutationMetadata(null, null, null, 0L, 1L, 23L, null, lastTransaction, 0L, 0);
+        new MysqlMutationMetadata(null, filePos, null, 0L, 1L, 23L, null, lastTransaction, 0L, 0);
 
     source.checkpoint(new MysqlInsertMutation(metadata, null));
 
@@ -195,7 +196,7 @@ public class MysqlSourceTest {
     TestSource source = new TestSource(stateHistory);
 
     Row row = new Row(null, ImmutableMap.of());
-    BinlogFilePos filePos = new BinlogFilePos("test.txt", 18, 156);
+    BinlogFilePos filePos = new BinlogFilePos("mysql-binlog.123450", 18, 156);
     Transaction lastTransaction = new Transaction(0L, 0L, filePos);
     MysqlMutationMetadata metadata =
         new MysqlMutationMetadata(null, filePos, null, 0L, 0L, 0L, null, lastTransaction, 0, 0);

--- a/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/util/JsonSerializationTest.java
+++ b/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/util/JsonSerializationTest.java
@@ -10,6 +10,7 @@ import com.airbnb.spinaltap.common.source.SourceState;
 import com.airbnb.spinaltap.common.util.JsonUtil;
 import com.airbnb.spinaltap.mysql.BinlogFilePos;
 import com.airbnb.spinaltap.mysql.DataSource;
+import com.airbnb.spinaltap.mysql.GtidSet;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.Queues;
 import java.util.Collection;
@@ -20,6 +21,7 @@ public class JsonSerializationTest {
   private static final DataSource DATA_SOURCE = new DataSource("test", 3306, "test_service");
   private static final BinlogFilePos BINLOG_FILE_POS = new BinlogFilePos("test.218", 1234, 5678);
   private static final SourceState SOURCE_STATE = new SourceState(15l, 20l, -1l, BINLOG_FILE_POS);
+  private static final String SERVER_UUID = "4a4ac150-fe5b-4093-a1ef-a8876011adaa";
 
   @Test
   public void testSerializeDataSource() throws Exception {
@@ -36,6 +38,29 @@ public class JsonSerializationTest {
         JsonUtil.OBJECT_MAPPER.readValue(
             JsonUtil.OBJECT_MAPPER.writeValueAsString(BINLOG_FILE_POS),
             new TypeReference<BinlogFilePos>() {}));
+  }
+
+  @Test
+  public void testSerializeBinlogFilePosWithGTID() throws Exception {
+    BinlogFilePos pos =
+        new BinlogFilePos("test.123", 123, 456, new GtidSet(SERVER_UUID + ":1-123"), SERVER_UUID);
+    assertEquals(
+        pos,
+        JsonUtil.OBJECT_MAPPER.readValue(
+            JsonUtil.OBJECT_MAPPER.writeValueAsString(pos), new TypeReference<BinlogFilePos>() {}));
+  }
+
+  @Test
+  public void testDeserialzeBinlogFilePosWithoutGTID() throws Exception {
+    String jsonString = "{\"fileName\": \"test.123\", \"position\": 4, \"nextPosition\": 8}";
+    BinlogFilePos pos =
+        JsonUtil.OBJECT_MAPPER.readValue(jsonString, new TypeReference<BinlogFilePos>() {});
+    assertEquals("test.123", pos.getFileName());
+    assertEquals(123, pos.getFileNumber());
+    assertEquals(4, pos.getPosition());
+    assertEquals(8, pos.getNextPosition());
+    assertNull(pos.getServerUUID());
+    assertNull(pos.getGtidSet());
   }
 
   @Test

--- a/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/util/JsonSerializationTest.java
+++ b/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/util/JsonSerializationTest.java
@@ -10,7 +10,6 @@ import com.airbnb.spinaltap.common.source.SourceState;
 import com.airbnb.spinaltap.common.util.JsonUtil;
 import com.airbnb.spinaltap.mysql.BinlogFilePos;
 import com.airbnb.spinaltap.mysql.DataSource;
-import com.airbnb.spinaltap.mysql.GtidSet;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.Queues;
 import java.util.Collection;
@@ -43,7 +42,7 @@ public class JsonSerializationTest {
   @Test
   public void testSerializeBinlogFilePosWithGTID() throws Exception {
     BinlogFilePos pos =
-        new BinlogFilePos("test.123", 123, 456, new GtidSet(SERVER_UUID + ":1-123"), SERVER_UUID);
+        new BinlogFilePos("test.123", 123, 456, SERVER_UUID + ":1-123", SERVER_UUID);
     assertEquals(
         pos,
         JsonUtil.OBJECT_MAPPER.readValue(


### PR DESCRIPTION
This PR attempts to add support for GTID with the following changes:

1. Created a `GtidSet` class to represent GTIDSet, this is an improvement of the `GtidSet` class in mysql-binlog-connector.
2. Added two more fields `gtidSet` and `serverUUID` to `BinlogFilePos` class. Adjusted the Jackson deserialization and `compareTo()` method to adapt non-GTID scenarios. (should not break current code which depends on this class.)
3. Added a `gtid` field to `Transaction` class.
4. Capture GTID events in binlog.
5. Created a `MysqlClient` class, which helps to query server global variables, master status and check whether `gtid_mode` is ON.
6. Added more optional fields to thrift schema.
7. Updated the logic in committing checkpoints, set starting binlog position to stream, etc.

Tested the change does not break server setups without GTID turned on.
Tested the failover scenario and SpinalTap should resume from the last checkpoint with GTID offset.

TODO: table schema versioning should also support GTID based lookup and comparison.

Reviewers: @mangobatao 