### PR TITLE
Generify StateRepository StateHistory

### DIFF
--- a/spinaltap-common/src/main/java/com/airbnb/spinaltap/common/pipe/AbstractPipeFactory.java
+++ b/spinaltap-common/src/main/java/com/airbnb/spinaltap/common/pipe/AbstractPipeFactory.java
@@ -6,6 +6,7 @@ package com.airbnb.spinaltap.common.pipe;
 
 import com.airbnb.common.metrics.TaggedMetricRegistry;
 import com.airbnb.spinaltap.common.config.SourceConfiguration;
+import com.airbnb.spinaltap.common.source.SourceState;
 import com.airbnb.spinaltap.common.util.StateRepositoryFactory;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -15,7 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
-public abstract class AbstractPipeFactory<T extends SourceConfiguration> {
+public abstract class AbstractPipeFactory<S extends SourceState, T extends SourceConfiguration> {
   private static String HOST_NAME = "unknown";
 
   protected final TaggedMetricRegistry metricRegistry;
@@ -23,7 +24,7 @@ public abstract class AbstractPipeFactory<T extends SourceConfiguration> {
   public abstract List<Pipe> createPipes(
       T sourceConfig,
       String partitionName,
-      StateRepositoryFactory repositoryFactory,
+      StateRepositoryFactory<S> repositoryFactory,
       long leaderEpoch)
       throws Exception;
 

--- a/spinaltap-common/src/main/java/com/airbnb/spinaltap/common/source/MysqlSourceState.java
+++ b/spinaltap-common/src/main/java/com/airbnb/spinaltap/common/source/MysqlSourceState.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2019 Airbnb. Licensed under Apache-2.0. See License in the project root for license
+ * information.
+ */
+package com.airbnb.spinaltap.common.source;
+
+import com.airbnb.spinaltap.mysql.BinlogFilePos;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/**
+ * Represents the state of a {@link Source}, based on the last {@link SourceEvent} streamed. This is
+ * used to mark the checkpoint for the {@link Source}, which will help indicate what position to
+ * point to in the changelog on restart.
+ *
+ * <p>At the moment, the implement is coupled to binlog event state and therefore confined to {@code
+ * MysqlSource} usage.
+ */
+@Data
+@EqualsAndHashCode(callSuper = true)
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MysqlSourceState extends SourceState {
+  /** The timestamp of the last streamed {@link SourceEvent} in the changelog. */
+  @JsonProperty private long lastTimestamp;
+
+  /** The offset of the last streamed {@link SourceEvent} in the changelog. */
+  @JsonProperty private long lastOffset;
+
+  /** The {@link BinlogFilePos} of the last streamed {@link SourceEvent} in the changelog. */
+  @JsonProperty private BinlogFilePos lastPosition;
+
+  public MysqlSourceState(
+      final long lastTimestamp,
+      final long lastOffset,
+      final long currentLeaderEpoch,
+      final BinlogFilePos lastPosition) {
+    super(currentLeaderEpoch);
+    this.lastTimestamp = lastTimestamp;
+    this.lastOffset = lastOffset;
+    this.lastPosition = lastPosition;
+  }
+}

--- a/spinaltap-common/src/main/java/com/airbnb/spinaltap/common/source/SourceState.java
+++ b/spinaltap-common/src/main/java/com/airbnb/spinaltap/common/source/SourceState.java
@@ -4,36 +4,17 @@
  */
 package com.airbnb.spinaltap.common.source;
 
-import com.airbnb.spinaltap.mysql.BinlogFilePos;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
-/**
- * Represents the state of a {@link Source}, based on the last {@link SourceEvent} streamed. This is
- * used to mark the checkpoint for the {@link Source}, which will help indicate what position to
- * point to in the changelog on restart.
- *
- * <p>At the moment, the implement is coupled to binlog event state and therefore confined to {@code
- * MysqlSource} usage.
- */
-@Getter
-@ToString
-@EqualsAndHashCode
+@Data
 @NoArgsConstructor
 @AllArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class SourceState {
-  /** The timestamp of the last streamed {@link SourceEvent} in the changelog. */
-  @JsonProperty private long lastTimestamp;
-
-  /** The offset of the last streamed {@link SourceEvent} in the changelog. */
-  @JsonProperty private long lastOffset;
-
+public abstract class SourceState {
   /**
    * The leader epoch for the {@code Source}. The epoch acts as a high watermark, and is typically
    * incremented on leader election.
@@ -43,7 +24,4 @@ public class SourceState {
    * streaming from the same {@link Source}.
    */
   @JsonProperty private long currentLeaderEpoch;
-
-  /** The {@link BinlogFilePos} of the last streamed {@link SourceEvent} in the changelog. */
-  @JsonProperty private BinlogFilePos lastPosition;
 }

--- a/spinaltap-common/src/main/java/com/airbnb/spinaltap/common/util/StateRepositoryFactory.java
+++ b/spinaltap-common/src/main/java/com/airbnb/spinaltap/common/util/StateRepositoryFactory.java
@@ -4,21 +4,21 @@
  */
 package com.airbnb.spinaltap.common.util;
 
+import com.airbnb.spinaltap.common.source.MysqlSourceState;
 import com.airbnb.spinaltap.common.source.SourceState;
 import java.util.Collection;
 
 /** Factory for {@link Repository}s that store {@link SourceState} objects. */
-public interface StateRepositoryFactory {
+public interface StateRepositoryFactory<S extends SourceState> {
   /**
-   * @return the {@link Repository} of the {@link SourceState} object for a given resource and
+   * @return the {@link Repository} of the {@link MysqlSourceState} object for a given resource and
    *     partition.
    */
-  Repository<SourceState> getStateRepository(String resourceName, String partitionName);
+  Repository<S> getStateRepository(String resourceName, String partitionName);
 
   /**
    * @return the {@link Repository} of the history of {@link SourceState} objects for a given
    *     resource and partition.
    */
-  Repository<Collection<SourceState>> getStateHistoryRepository(
-      String resourceName, String partitionName);
+  Repository<Collection<S>> getStateHistoryRepository(String resourceName, String partitionName);
 }

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/MysqlPipeFactory.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/MysqlPipeFactory.java
@@ -13,6 +13,7 @@ import com.airbnb.spinaltap.common.destination.DestinationBuilder;
 import com.airbnb.spinaltap.common.pipe.AbstractPipeFactory;
 import com.airbnb.spinaltap.common.pipe.Pipe;
 import com.airbnb.spinaltap.common.pipe.PipeMetrics;
+import com.airbnb.spinaltap.common.source.MysqlSourceState;
 import com.airbnb.spinaltap.common.source.Source;
 import com.airbnb.spinaltap.common.util.StateRepositoryFactory;
 import com.airbnb.spinaltap.mysql.config.MysqlConfiguration;
@@ -30,7 +31,8 @@ import lombok.extern.slf4j.Slf4j;
 
 /** Represents a factory implement for {@link Pipe}s streaming from a {@link MysqlSource}. */
 @Slf4j
-public final class MysqlPipeFactory extends AbstractPipeFactory<MysqlConfiguration> {
+public final class MysqlPipeFactory
+    extends AbstractPipeFactory<MysqlSourceState, MysqlConfiguration> {
   public static final String DEFAULT_MYSQL_TOPIC_PREFIX = "spinaltap";
 
   @NonNull private final String mysqlUser;
@@ -78,7 +80,7 @@ public final class MysqlPipeFactory extends AbstractPipeFactory<MysqlConfigurati
   public List<Pipe> createPipes(
       @NonNull final MysqlConfiguration sourceConfig,
       @NonNull final String partitionName,
-      @NonNull final StateRepositoryFactory repositoryFactory,
+      @NonNull final StateRepositoryFactory<MysqlSourceState> repositoryFactory,
       @Min(0) final long leaderEpoch)
       throws Exception {
     return Collections.singletonList(
@@ -88,7 +90,7 @@ public final class MysqlPipeFactory extends AbstractPipeFactory<MysqlConfigurati
   private Pipe create(
       final MysqlConfiguration sourceConfig,
       final String partitionName,
-      final StateRepositoryFactory repositoryFactory,
+      final StateRepositoryFactory<MysqlSourceState> repositoryFactory,
       final long leaderEpoch)
       throws Exception {
     final Source source = createSource(sourceConfig, repositoryFactory, partitionName, leaderEpoch);
@@ -106,7 +108,7 @@ public final class MysqlPipeFactory extends AbstractPipeFactory<MysqlConfigurati
 
   private Source createSource(
       final MysqlConfiguration configuration,
-      final StateRepositoryFactory repositoryFactory,
+      final StateRepositoryFactory<MysqlSourceState> repositoryFactory,
       final String partitionName,
       final long leaderEpoch) {
     return MysqlSourceFactory.create(

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/MysqlSourceFactory.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/MysqlSourceFactory.java
@@ -5,8 +5,8 @@
 package com.airbnb.spinaltap.mysql;
 
 import com.airbnb.spinaltap.common.config.TlsConfiguration;
+import com.airbnb.spinaltap.common.source.MysqlSourceState;
 import com.airbnb.spinaltap.common.source.Source;
-import com.airbnb.spinaltap.common.source.SourceState;
 import com.airbnb.spinaltap.common.util.Repository;
 import com.airbnb.spinaltap.common.validator.MutationOrderValidator;
 import com.airbnb.spinaltap.mysql.binlog_connector.BinaryLogConnectorSource;
@@ -31,8 +31,8 @@ public class MysqlSourceFactory {
       @NonNull final String password,
       @Min(0) final long serverId,
       final TlsConfiguration tlsConfiguration,
-      @NonNull final Repository<SourceState> backingStateRepository,
-      @NonNull final Repository<Collection<SourceState>> stateHistoryRepository,
+      @NonNull final Repository<MysqlSourceState> backingStateRepository,
+      @NonNull final Repository<Collection<MysqlSourceState>> stateHistoryRepository,
       final MysqlSchemaManagerFactory schemaManagerFactory,
       @NonNull final MysqlSourceMetrics metrics,
       @Min(0) final long leaderEpoch) {
@@ -51,9 +51,10 @@ public class MysqlSourceFactory {
       binlogClient.setServerId(serverId);
     }
 
-    final StateRepository stateRepository =
-        new StateRepository(name, backingStateRepository, metrics);
-    final StateHistory stateHistory = new StateHistory(name, stateHistoryRepository, metrics);
+    final StateRepository<MysqlSourceState> stateRepository =
+        new StateRepository<>(name, backingStateRepository, metrics);
+    final StateHistory<MysqlSourceState> stateHistory =
+        new StateHistory<>(name, stateHistoryRepository, metrics);
 
     final MysqlClient mysqlClient =
         MysqlClient.create(

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/StateRepository.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/StateRepository.java
@@ -13,13 +13,13 @@ import lombok.extern.slf4j.Slf4j;
 /** Represents a repository for a {@link SourceState} record. */
 @Slf4j
 @RequiredArgsConstructor
-public class StateRepository {
+public class StateRepository<S extends SourceState> {
   @NonNull private final String sourceName;
-  @NonNull private final Repository<SourceState> repository;
+  @NonNull private final Repository<S> repository;
   @NonNull private final MysqlSourceMetrics metrics;
 
   /** Saves or updates the {@link SourceState} record in the repository */
-  public void save(@NonNull final SourceState state) {
+  public void save(@NonNull final S state) {
     try {
       repository.update(
           state,
@@ -42,8 +42,8 @@ public class StateRepository {
   }
 
   /** @return the {@link SourceState} record present in the repository. */
-  public SourceState read() {
-    SourceState state = null;
+  public S read() {
+    S state = null;
 
     try {
       if (repository.exists()) {

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/TableCache.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/TableCache.java
@@ -51,20 +51,18 @@ public class TableCache {
    * @param tableId The table id
    * @param tableName The table name
    * @param database The database name
-   * @param binlogFilePos The binlog file position
    * @param columnTypes The list of columnd data types
    */
   public void addOrUpdate(
       @Min(0) final long tableId,
       @NonNull final String tableName,
       @NonNull final String database,
-      @NonNull final BinlogFilePos binlogFilePos,
       @NonNull final List<ColumnDataType> columnTypes)
       throws Exception {
     final Table table = tableCache.getIfPresent(tableId);
 
     if (table == null || !validTable(table, tableName, database, columnTypes)) {
-      tableCache.put(tableId, fetchTable(tableId, database, tableName, binlogFilePos, columnTypes));
+      tableCache.put(tableId, fetchTable(tableId, database, tableName, columnTypes));
     }
   }
 
@@ -99,7 +97,6 @@ public class TableCache {
       final long tableId,
       final String databaseName,
       final String tableName,
-      final BinlogFilePos binlogFilePos,
       final List<ColumnDataType> columnTypes)
       throws Exception {
     final List<MysqlColumn> tableSchema = schemaManager.getTableColumns(databaseName, tableName);

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/binlog_connector/BinaryLogConnectorSource.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/binlog_connector/BinaryLogConnectorSource.java
@@ -5,6 +5,7 @@
 package com.airbnb.spinaltap.mysql.binlog_connector;
 
 import com.airbnb.spinaltap.common.config.TlsConfiguration;
+import com.airbnb.spinaltap.common.source.MysqlSourceState;
 import com.airbnb.spinaltap.mysql.BinlogFilePos;
 import com.airbnb.spinaltap.mysql.DataSource;
 import com.airbnb.spinaltap.mysql.MysqlClient;
@@ -49,8 +50,8 @@ public final class BinaryLogConnectorSource extends MysqlSource {
       @NonNull final BinaryLogClient binlogClient,
       @NonNull final MysqlClient mysqlClient,
       @NonNull final TableCache tableCache,
-      @NonNull final StateRepository stateRepository,
-      @NonNull final StateHistory stateHistory,
+      @NonNull final StateRepository<MysqlSourceState> stateRepository,
+      @NonNull final StateHistory<MysqlSourceState> stateHistory,
       @NonNull final MysqlSchemaManager schemaManager,
       @NonNull final MysqlSourceMetrics metrics,
       @NonNull final AtomicLong currentLeaderEpoch) {

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/event/filter/DuplicateFilter.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/event/filter/DuplicateFilter.java
@@ -4,7 +4,7 @@
  */
 package com.airbnb.spinaltap.mysql.event.filter;
 
-import com.airbnb.spinaltap.common.source.SourceState;
+import com.airbnb.spinaltap.common.source.MysqlSourceState;
 import com.airbnb.spinaltap.mysql.BinlogFilePos;
 import com.airbnb.spinaltap.mysql.GtidSet;
 import com.airbnb.spinaltap.mysql.event.BinlogEvent;
@@ -15,12 +15,12 @@ import lombok.RequiredArgsConstructor;
 /**
  * Represents a {@link com.airbnb.spinaltap.common.util.Filter} for duplicate {@link BinlogEvent}s
  * that have already been streamed. This is used for server-side de-duplication, by comparing
- * against the offset of the last marked {@link SourceState} checkpoint and disregarding any events
- * that are received with an offset before that watermark.
+ * against the offset of the last marked {@link MysqlSourceState} checkpoint and disregarding any
+ * events that are received with an offset before that watermark.
  */
 @RequiredArgsConstructor
 public final class DuplicateFilter extends MysqlEventFilter {
-  @NonNull private final AtomicReference<SourceState> state;
+  @NonNull private final AtomicReference<MysqlSourceState> state;
 
   public boolean apply(@NonNull final BinlogEvent event) {
     // Only applies to mutation events

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/event/filter/MysqlEventFilter.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/event/filter/MysqlEventFilter.java
@@ -4,7 +4,7 @@
  */
 package com.airbnb.spinaltap.mysql.event.filter;
 
-import com.airbnb.spinaltap.common.source.SourceState;
+import com.airbnb.spinaltap.common.source.MysqlSourceState;
 import com.airbnb.spinaltap.common.util.ChainedFilter;
 import com.airbnb.spinaltap.common.util.Filter;
 import com.airbnb.spinaltap.mysql.TableCache;
@@ -18,7 +18,7 @@ public abstract class MysqlEventFilter implements Filter<BinlogEvent> {
   public static Filter<BinlogEvent> create(
       @NonNull final TableCache tableCache,
       @NonNull final Set<String> tableNames,
-      @NonNull final AtomicReference<SourceState> state) {
+      @NonNull final AtomicReference<MysqlSourceState> state) {
     return ChainedFilter.<BinlogEvent>builder()
         .addFilter(new EventTypeFilter())
         .addFilter(new TableFilter(tableCache, tableNames))

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/event/mapper/TableMapMapper.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/event/mapper/TableMapMapper.java
@@ -32,11 +32,7 @@ final class TableMapMapper implements Mapper<TableMapEvent, List<MysqlMutation>>
   public List<MysqlMutation> map(@NonNull final TableMapEvent event) {
     try {
       tableCache.addOrUpdate(
-          event.getTableId(),
-          event.getTable(),
-          event.getDatabase(),
-          event.getBinlogFilePos(),
-          event.getColumnTypes());
+          event.getTableId(), event.getTable(), event.getDatabase(), event.getColumnTypes());
     } catch (Exception ex) {
       log.error("Failed to process table map event: " + event, ex);
       throw new RuntimeException(ex);

--- a/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/StateHistoryTest.java
+++ b/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/StateHistoryTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
-import com.airbnb.spinaltap.common.source.SourceState;
+import com.airbnb.spinaltap.common.source.MysqlSourceState;
 import com.airbnb.spinaltap.common.util.Repository;
 import com.google.common.collect.Lists;
 import java.util.Arrays;
@@ -26,13 +26,14 @@ public class StateHistoryTest {
 
   @Test
   public void test() throws Exception {
-    SourceState firstState = mock(SourceState.class);
-    SourceState secondState = mock(SourceState.class);
-    SourceState thirdState = mock(SourceState.class);
-    SourceState fourthState = mock(SourceState.class);
+    MysqlSourceState firstState = mock(MysqlSourceState.class);
+    MysqlSourceState secondState = mock(MysqlSourceState.class);
+    MysqlSourceState thirdState = mock(MysqlSourceState.class);
+    MysqlSourceState fourthState = mock(MysqlSourceState.class);
 
     TestRepository repository = new TestRepository(firstState);
-    StateHistory history = new StateHistory(SOURCE_NAME, 2, repository, metrics);
+    StateHistory<MysqlSourceState> history =
+        new StateHistory<>(SOURCE_NAME, 2, repository, metrics);
 
     history.add(secondState);
 
@@ -46,25 +47,27 @@ public class StateHistoryTest {
 
   @Test
   public void testEmptyHistory() throws Exception {
-    SourceState state = mock(SourceState.class);
+    MysqlSourceState state = mock(MysqlSourceState.class);
 
     TestRepository repository = new TestRepository();
-    StateHistory history = new StateHistory(SOURCE_NAME, 2, repository, metrics);
+    StateHistory<MysqlSourceState> history =
+        new StateHistory<>(SOURCE_NAME, 2, repository, metrics);
     assertTrue(history.isEmpty());
 
     repository = new TestRepository(state);
-    history = new StateHistory(SOURCE_NAME, 2, repository, metrics);
+    history = new StateHistory<>(SOURCE_NAME, 2, repository, metrics);
     assertFalse(history.isEmpty());
   }
 
   @Test
   public void testRemoveLastFromHistory() throws Exception {
-    SourceState firstState = mock(SourceState.class);
-    SourceState secondState = mock(SourceState.class);
-    SourceState thirdState = mock(SourceState.class);
+    MysqlSourceState firstState = mock(MysqlSourceState.class);
+    MysqlSourceState secondState = mock(MysqlSourceState.class);
+    MysqlSourceState thirdState = mock(MysqlSourceState.class);
 
     TestRepository repository = new TestRepository(firstState, secondState, thirdState);
-    StateHistory history = new StateHistory(SOURCE_NAME, 3, repository, metrics);
+    StateHistory<MysqlSourceState> history =
+        new StateHistory<>(SOURCE_NAME, 3, repository, metrics);
 
     assertEquals(thirdState, history.removeLast());
     assertEquals(secondState, history.removeLast());
@@ -74,28 +77,31 @@ public class StateHistoryTest {
 
   @Test(expected = IllegalStateException.class)
   public void testRemoveFromEmptyHistory() throws Exception {
-    StateHistory history = new StateHistory(SOURCE_NAME, 2, new TestRepository(), metrics);
+    StateHistory<MysqlSourceState> history =
+        new StateHistory<>(SOURCE_NAME, 2, new TestRepository(), metrics);
     history.removeLast();
   }
 
   @Test(expected = IllegalStateException.class)
   public void testRemoveMoreElementsThanInHistory() throws Exception {
-    SourceState firstState = mock(SourceState.class);
-    SourceState secondState = mock(SourceState.class);
+    MysqlSourceState firstState = mock(MysqlSourceState.class);
+    MysqlSourceState secondState = mock(MysqlSourceState.class);
 
     TestRepository repository = new TestRepository(firstState, secondState);
-    StateHistory history = new StateHistory(SOURCE_NAME, 2, repository, metrics);
+    StateHistory<MysqlSourceState> history =
+        new StateHistory<>(SOURCE_NAME, 2, repository, metrics);
 
     history.removeLast(3);
   }
 
   @Test
   public void testRemoveAllElementsFromHistory() throws Exception {
-    SourceState firstState = mock(SourceState.class);
-    SourceState secondState = mock(SourceState.class);
+    MysqlSourceState firstState = mock(MysqlSourceState.class);
+    MysqlSourceState secondState = mock(MysqlSourceState.class);
 
     TestRepository repository = new TestRepository(firstState, secondState);
-    StateHistory history = new StateHistory(SOURCE_NAME, 2, repository, metrics);
+    StateHistory<MysqlSourceState> history =
+        new StateHistory<>(SOURCE_NAME, 2, repository, metrics);
 
     assertEquals(firstState, history.removeLast(2));
     assertTrue(history.isEmpty());
@@ -103,12 +109,13 @@ public class StateHistoryTest {
 
   @Test
   public void testRemoveMultipleElementsFromHistory() throws Exception {
-    SourceState firstState = mock(SourceState.class);
-    SourceState secondState = mock(SourceState.class);
-    SourceState thirdState = mock(SourceState.class);
+    MysqlSourceState firstState = mock(MysqlSourceState.class);
+    MysqlSourceState secondState = mock(MysqlSourceState.class);
+    MysqlSourceState thirdState = mock(MysqlSourceState.class);
 
     TestRepository repository = new TestRepository(firstState, secondState, thirdState);
-    StateHistory history = new StateHistory(SOURCE_NAME, 3, repository, metrics);
+    StateHistory<MysqlSourceState> history =
+        new StateHistory<>(SOURCE_NAME, 3, repository, metrics);
 
     assertEquals(secondState, history.removeLast(2));
     assertEquals(Collections.singletonList(firstState), repository.get());
@@ -116,7 +123,7 @@ public class StateHistoryTest {
 
   @Test
   public void testRemoveStateHistory() throws Exception {
-    TestRepository repository = new TestRepository(mock(SourceState.class));
+    TestRepository repository = new TestRepository(mock(MysqlSourceState.class));
     assertTrue(repository.exists());
     repository.remove();
     assertFalse(repository.exists());
@@ -124,10 +131,10 @@ public class StateHistoryTest {
 
   @NoArgsConstructor
   @AllArgsConstructor
-  public class TestRepository implements Repository<Collection<SourceState>> {
-    private List<SourceState> states;
+  public static class TestRepository implements Repository<Collection<MysqlSourceState>> {
+    private List<MysqlSourceState> states;
 
-    TestRepository(SourceState... states) {
+    TestRepository(MysqlSourceState... states) {
       this(Arrays.asList(states));
     }
 
@@ -137,23 +144,24 @@ public class StateHistoryTest {
     }
 
     @Override
-    public void create(Collection<SourceState> states) throws Exception {
+    public void create(Collection<MysqlSourceState> states) throws Exception {
       this.states = Lists.newArrayList(states);
     }
 
     @Override
-    public void set(Collection<SourceState> states) throws Exception {
+    public void set(Collection<MysqlSourceState> states) throws Exception {
       create(states);
     }
 
     @Override
-    public void update(Collection<SourceState> states, DataUpdater<Collection<SourceState>> updater)
+    public void update(
+        Collection<MysqlSourceState> states, DataUpdater<Collection<MysqlSourceState>> updater)
         throws Exception {
       create(states);
     }
 
     @Override
-    public Collection<SourceState> get() throws Exception {
+    public Collection<MysqlSourceState> get() throws Exception {
       return states;
     }
 

--- a/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/TableCacheTest.java
+++ b/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/TableCacheTest.java
@@ -84,13 +84,13 @@ public class TableCacheTest {
 
     assertNull(tableCache.get(TABLE_ID));
 
-    tableCache.addOrUpdate(TABLE_ID, TABLE_NAME, DATABASE_NAME, binlogFilePos, columnTypes);
+    tableCache.addOrUpdate(TABLE_ID, TABLE_NAME, DATABASE_NAME, columnTypes);
 
     Table table = tableCache.get(TABLE_ID);
     assertEquals(TABLE, table);
     verify(schemaManager, times(1)).getTableColumns(DATABASE_NAME, TABLE_NAME);
 
-    tableCache.addOrUpdate(TABLE_ID, TABLE_NAME, DATABASE_NAME, binlogFilePos, columnTypes);
+    tableCache.addOrUpdate(TABLE_ID, TABLE_NAME, DATABASE_NAME, columnTypes);
 
     table = tableCache.get(TABLE_ID);
     assertEquals(TABLE, table);
@@ -101,13 +101,13 @@ public class TableCacheTest {
     when(schemaManager.getTableColumns(DATABASE_NAME, TABLE_NAME))
         .thenReturn(TABLE_COLUMNS_UPDATED);
 
-    tableCache.addOrUpdate(TABLE_ID, TABLE_NAME, DATABASE_NAME, binlogFilePos, columnTypes);
+    tableCache.addOrUpdate(TABLE_ID, TABLE_NAME, DATABASE_NAME, columnTypes);
 
     table = tableCache.get(TABLE_ID);
     assertEquals(TABLE_UPDATED, table);
     verify(schemaManager, times(2)).getTableColumns(DATABASE_NAME, TABLE_NAME);
 
-    tableCache.addOrUpdate(TABLE_ID, TABLE_NAME, DATABASE_NAME, binlogFilePos, columnTypes);
+    tableCache.addOrUpdate(TABLE_ID, TABLE_NAME, DATABASE_NAME, columnTypes);
 
     table = tableCache.get(TABLE_ID);
     assertEquals(TABLE_UPDATED, table);
@@ -121,7 +121,7 @@ public class TableCacheTest {
     when(schemaManager.getTableColumns(DATABASE_NAME, TABLE_NAME))
         .thenReturn(TABLE_COLUMNS_LARGE_STUB);
 
-    tableCache.addOrUpdate(TABLE_ID, TABLE_NAME, DATABASE_NAME, binlogFilePos, columnTypes);
+    tableCache.addOrUpdate(TABLE_ID, TABLE_NAME, DATABASE_NAME, columnTypes);
 
     table = tableCache.get(TABLE_ID);
     assertEquals(TABLE, table);
@@ -138,14 +138,14 @@ public class TableCacheTest {
         Arrays.asList(
             ColumnDataType.TINY, ColumnDataType.STRING, ColumnDataType.FLOAT, ColumnDataType.LONG);
 
-    tableCache.addOrUpdate(TABLE_ID, TABLE_NAME, DATABASE_NAME, binlogFilePos, columnTypes);
+    tableCache.addOrUpdate(TABLE_ID, TABLE_NAME, DATABASE_NAME, columnTypes);
 
     verify(schemaManager, times(1)).getTableColumns(DATABASE_NAME, TABLE_NAME);
 
     when(schemaManager.getTableColumns(DATABASE_NAME, newTable)).thenReturn(TABLE_COLUMNS_UPDATED);
     columnTypes = Arrays.asList(ColumnDataType.TINY, ColumnDataType.STRING, ColumnDataType.FLOAT);
 
-    tableCache.addOrUpdate(TABLE_ID, newTable, DATABASE_NAME, binlogFilePos, columnTypes);
+    tableCache.addOrUpdate(TABLE_ID, newTable, DATABASE_NAME, columnTypes);
 
     verify(schemaManager, times(1)).getTableColumns(DATABASE_NAME, newTable);
     verifyZeroInteractions(metrics);

--- a/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/event/filter/MysqlEventFilterTest.java
+++ b/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/event/filter/MysqlEventFilterTest.java
@@ -7,7 +7,7 @@ package com.airbnb.spinaltap.mysql.event.filter;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
-import com.airbnb.spinaltap.common.source.SourceState;
+import com.airbnb.spinaltap.common.source.MysqlSourceState;
 import com.airbnb.spinaltap.common.util.Filter;
 import com.airbnb.spinaltap.mysql.BinlogFilePos;
 import com.airbnb.spinaltap.mysql.TableCache;
@@ -39,7 +39,7 @@ public class MysqlEventFilterTest {
     TableCache tableCache = mock(TableCache.class);
     BinlogEvent lastEvent = new XidEvent(0l, 0l, BINLOG_FILE_POS, 0l);
     BinlogFilePos nextPosition = new BinlogFilePos("test.123", 15, 100);
-    SourceState state = new SourceState(0l, lastEvent.getOffset(), 0l, BINLOG_FILE_POS);
+    MysqlSourceState state = new MysqlSourceState(0l, lastEvent.getOffset(), 0l, BINLOG_FILE_POS);
     Filter<BinlogEvent> filter =
         MysqlEventFilter.create(tableCache, TABLE_NAMES, new AtomicReference(state));
 

--- a/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/event/mapper/MysqlMutationMapperTest.java
+++ b/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/event/mapper/MysqlMutationMapperTest.java
@@ -362,7 +362,7 @@ public class MysqlMutationMapperTest {
 
     assertTrue(mutations.isEmpty());
     verify(tableCache, times(1))
-        .addOrUpdate(TABLE_ID, TABLE_NAME, DATABASE_NAME, BINLOG_FILE_POS, event.getColumnTypes());
+        .addOrUpdate(TABLE_ID, TABLE_NAME, DATABASE_NAME, event.getColumnTypes());
   }
 
   @Test

--- a/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/util/JsonSerializationTest.java
+++ b/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/util/JsonSerializationTest.java
@@ -6,7 +6,7 @@ package com.airbnb.spinaltap.mysql.util;
 
 import static org.junit.Assert.*;
 
-import com.airbnb.spinaltap.common.source.SourceState;
+import com.airbnb.spinaltap.common.source.MysqlSourceState;
 import com.airbnb.spinaltap.common.util.JsonUtil;
 import com.airbnb.spinaltap.mysql.BinlogFilePos;
 import com.airbnb.spinaltap.mysql.DataSource;
@@ -24,7 +24,8 @@ import org.junit.Test;
 public class JsonSerializationTest {
   private static final DataSource DATA_SOURCE = new DataSource("test", 3306, "test_service");
   private static final BinlogFilePos BINLOG_FILE_POS = new BinlogFilePos("test.218", 1234, 5678);
-  private static final SourceState SOURCE_STATE = new SourceState(15l, 20l, -1l, BINLOG_FILE_POS);
+  private static final MysqlSourceState SOURCE_STATE =
+      new MysqlSourceState(15l, 20l, -1l, BINLOG_FILE_POS);
   private static final String SERVER_UUID = "4a4ac150-fe5b-4093-a1ef-a8876011adaa";
 
   @Test
@@ -69,10 +70,10 @@ public class JsonSerializationTest {
 
   @Test
   public void testSerializeSourceState() throws Exception {
-    SourceState state =
+    MysqlSourceState state =
         JsonUtil.OBJECT_MAPPER.readValue(
             JsonUtil.OBJECT_MAPPER.writeValueAsString(SOURCE_STATE),
-            new TypeReference<SourceState>() {});
+            new TypeReference<MysqlSourceState>() {});
 
     assertEquals(BINLOG_FILE_POS, state.getLastPosition());
     assertEquals(SOURCE_STATE.getLastTimestamp(), state.getLastTimestamp());
@@ -81,19 +82,19 @@ public class JsonSerializationTest {
 
   @Test
   public void testSerializeStateHistory() throws Exception {
-    SourceState firstState = new SourceState(15l, 20l, -1l, BINLOG_FILE_POS);
-    SourceState secondState = new SourceState(16l, 21l, -1l, BINLOG_FILE_POS);
-    SourceState thirdState = new SourceState(17l, 22l, -1l, BINLOG_FILE_POS);
+    MysqlSourceState firstState = new MysqlSourceState(15l, 20l, -1l, BINLOG_FILE_POS);
+    MysqlSourceState secondState = new MysqlSourceState(16l, 21l, -1l, BINLOG_FILE_POS);
+    MysqlSourceState thirdState = new MysqlSourceState(17l, 22l, -1l, BINLOG_FILE_POS);
 
-    Deque<SourceState> stateHistory = Queues.newArrayDeque();
+    Deque<MysqlSourceState> stateHistory = Queues.newArrayDeque();
     stateHistory.addLast(firstState);
     stateHistory.addLast(secondState);
     stateHistory.addLast(thirdState);
 
-    Collection<SourceState> states =
+    Collection<MysqlSourceState> states =
         JsonUtil.OBJECT_MAPPER.readValue(
             JsonUtil.OBJECT_MAPPER.writeValueAsString(stateHistory),
-            new TypeReference<Collection<SourceState>>() {});
+            new TypeReference<Collection<MysqlSourceState>>() {});
 
     stateHistory = Queues.newArrayDeque(states);
 

--- a/spinaltap-standalone/src/main/java/com/airbnb/spinaltap/ZookeeperRepositoryFactory.java
+++ b/spinaltap-standalone/src/main/java/com/airbnb/spinaltap/ZookeeperRepositoryFactory.java
@@ -4,7 +4,7 @@
  */
 package com.airbnb.spinaltap;
 
-import com.airbnb.spinaltap.common.source.SourceState;
+import com.airbnb.spinaltap.common.source.MysqlSourceState;
 import com.airbnb.spinaltap.common.util.StateRepositoryFactory;
 import com.airbnb.spinaltap.common.util.ZookeeperRepository;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -15,23 +15,24 @@ import org.apache.curator.framework.CuratorFramework;
 
 /** Represents an implement of {@link StateRepositoryFactory} in Zookeeper. */
 @RequiredArgsConstructor
-public final class ZookeeperRepositoryFactory implements StateRepositoryFactory {
+public final class ZookeeperRepositoryFactory implements StateRepositoryFactory<MysqlSourceState> {
   @NonNull private final CuratorFramework zkClient;
 
   @Override
-  public ZookeeperRepository<SourceState> getStateRepository(String sourceName, String parition) {
+  public ZookeeperRepository<MysqlSourceState> getStateRepository(
+      String sourceName, String parition) {
     return new ZookeeperRepository<>(
         zkClient,
         String.format("/spinaltap/pipe/%s/state", sourceName),
-        new TypeReference<SourceState>() {});
+        new TypeReference<MysqlSourceState>() {});
   }
 
   @Override
-  public ZookeeperRepository<Collection<SourceState>> getStateHistoryRepository(
+  public ZookeeperRepository<Collection<MysqlSourceState>> getStateHistoryRepository(
       String sourceName, String partition) {
     return new ZookeeperRepository<>(
         zkClient,
         String.format("/spinaltap/pipe/%s/state_history", sourceName),
-        new TypeReference<Collection<SourceState>>() {});
+        new TypeReference<Collection<MysqlSourceState>>() {});
   }
 }


### PR DESCRIPTION
* Generify `StateRepository` and `StateHistory` so they are not coupled with `SourceState`.

* Rename `SourceState` to `MysqlSourceState` for MySQL only. Make `SourceState` the parent class.

@mangobatao 