### PR TITLE
make raw column type optional

### DIFF
--- a/spinaltap-kafka/src/test/java/com/airbnb/spinaltap/kafka/KafkaDestinationTest.java
+++ b/spinaltap-kafka/src/test/java/com/airbnb/spinaltap/kafka/KafkaDestinationTest.java
@@ -177,7 +177,7 @@ public class KafkaDestinationTest extends AbstractKafkaIntegrationTestHarness {
             TABLE,
             DATABASE,
             null,
-            ImmutableList.of(new ColumnMetadata("id", ColumnDataType.LONGLONG, true, 0, "")),
+            ImmutableList.of(new ColumnMetadata("id", ColumnDataType.LONGLONG, true, 0)),
             ImmutableList.of("id"));
     MysqlMutationMetadata metadata =
         new MysqlMutationMetadata(
@@ -195,8 +195,7 @@ public class KafkaDestinationTest extends AbstractKafkaIntegrationTestHarness {
         new Row(
             table,
             ImmutableMap.of(
-                "id",
-                new Column(new ColumnMetadata("id", ColumnDataType.LONGLONG, true, 0, ""), 1L)));
+                "id", new Column(new ColumnMetadata("id", ColumnDataType.LONGLONG, true, 0), 1L)));
     MysqlMutation mutation;
     switch (type) {
       case INSERT:

--- a/spinaltap-model/src/main/java/com/airbnb/spinaltap/mysql/mutation/schema/ColumnMetadata.java
+++ b/spinaltap-model/src/main/java/com/airbnb/spinaltap/mysql/mutation/schema/ColumnMetadata.java
@@ -4,14 +4,18 @@
  */
 package com.airbnb.spinaltap.mysql.mutation.schema;
 
-import lombok.Value;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
 
 /** Represents additional metadata on a MySQL {@link Column}. */
-@Value
+@Data
+@RequiredArgsConstructor
+@AllArgsConstructor
 public class ColumnMetadata {
   private final String name;
   private final ColumnDataType colType;
   private final boolean isPrimaryKey;
   private final int position;
-  private final String rawColumnType;
+  private String rawColumnType;
 }

--- a/spinaltap-model/src/test/java/com/airbnb/spinaltap/mysql/mutation/MysqlUpdateMutationTest.java
+++ b/spinaltap-model/src/test/java/com/airbnb/spinaltap/mysql/mutation/MysqlUpdateMutationTest.java
@@ -24,7 +24,7 @@ public class MysqlUpdateMutationTest {
             "table_name",
             "db_name",
             null,
-            ImmutableList.of(new ColumnMetadata("id", ColumnDataType.LONGLONG, false, 0, "")),
+            ImmutableList.of(new ColumnMetadata("id", ColumnDataType.LONGLONG, false, 0)),
             ImmutableList.of());
 
     Row row = new Row(table, ImmutableMap.of("id", new Column(table.getColumns().get("id"), 2)));

--- a/spinaltap-model/src/test/java/com/airbnb/spinaltap/mysql/schema/RowTest.java
+++ b/spinaltap-model/src/test/java/com/airbnb/spinaltap/mysql/schema/RowTest.java
@@ -31,7 +31,7 @@ public class RowTest {
             TABLE_NAME,
             DB_NAME,
             null,
-            ImmutableList.of(new ColumnMetadata(ID_COLUMN, ColumnDataType.LONGLONG, false, 0, "")),
+            ImmutableList.of(new ColumnMetadata(ID_COLUMN, ColumnDataType.LONGLONG, false, 0)),
             ImmutableList.of());
 
     Row row =
@@ -49,7 +49,7 @@ public class RowTest {
             TABLE_NAME,
             DB_NAME,
             null,
-            ImmutableList.of(new ColumnMetadata(ID_COLUMN, ColumnDataType.LONGLONG, true, 0, "")),
+            ImmutableList.of(new ColumnMetadata(ID_COLUMN, ColumnDataType.LONGLONG, true, 0)),
             ImmutableList.of(ID_COLUMN));
 
     Row row =
@@ -68,8 +68,8 @@ public class RowTest {
             DB_NAME,
             null,
             ImmutableList.of(
-                new ColumnMetadata(ID_COLUMN, ColumnDataType.LONGLONG, true, 0, ""),
-                new ColumnMetadata(NAME_COLUMN, ColumnDataType.VARCHAR, false, 1, "")),
+                new ColumnMetadata(ID_COLUMN, ColumnDataType.LONGLONG, true, 0),
+                new ColumnMetadata(NAME_COLUMN, ColumnDataType.VARCHAR, false, 1)),
             ImmutableList.of(ID_COLUMN));
 
     Row row =
@@ -91,8 +91,8 @@ public class RowTest {
             DB_NAME,
             null,
             ImmutableList.of(
-                new ColumnMetadata(ID_COLUMN, ColumnDataType.LONGLONG, true, 0, ""),
-                new ColumnMetadata(NAME_COLUMN, ColumnDataType.VARCHAR, true, 1, "")),
+                new ColumnMetadata(ID_COLUMN, ColumnDataType.LONGLONG, true, 0),
+                new ColumnMetadata(NAME_COLUMN, ColumnDataType.VARCHAR, true, 1)),
             ImmutableList.of(ID_COLUMN, NAME_COLUMN));
 
     Row row =

--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/TableCache.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/TableCache.java
@@ -112,13 +112,11 @@ public class TableCache {
     final List<ColumnMetadata> columnMetadata = new ArrayList<>();
     for (int position = 0; position < columnTypes.size() && schemaIterator.hasNext(); position++) {
       MysqlColumn colInfo = schemaIterator.next();
-      columnMetadata.add(
+      ColumnMetadata metadata =
           new ColumnMetadata(
-              colInfo.getName(),
-              columnTypes.get(position),
-              colInfo.isPrimaryKey(),
-              position,
-              colInfo.getColumnType()));
+              colInfo.getName(), columnTypes.get(position), colInfo.isPrimaryKey(), position);
+      metadata.setRawColumnType(colInfo.getColumnType());
+      columnMetadata.add(metadata);
     }
 
     final List<String> primaryColumns =

--- a/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/ColumnSerializationUtilTest.java
+++ b/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/ColumnSerializationUtilTest.java
@@ -64,22 +64,20 @@ public class ColumnSerializationUtilTest {
         "c1",
         ByteBuffer.wrap(
             ColumnSerializationUtil.serializeColumn(
-                new Column(new ColumnMetadata("c1", ColumnDataType.INT24, false, 0, ""), 12345))),
+                new Column(new ColumnMetadata("c1", ColumnDataType.INT24, false, 0), 12345))),
         "c2",
         ByteBuffer.wrap(
             ColumnSerializationUtil.serializeColumn(
-                new Column(
-                    new ColumnMetadata("c2", ColumnDataType.STRING, false, 1, ""), "string"))),
+                new Column(new ColumnMetadata("c2", ColumnDataType.STRING, false, 1), "string"))),
         "c3",
         ByteBuffer.wrap(
             ColumnSerializationUtil.serializeColumn(
                 new Column(
-                    new ColumnMetadata("c3", ColumnDataType.BLOB, false, 2, ""),
+                    new ColumnMetadata("c3", ColumnDataType.BLOB, false, 2),
                     "blob.data".getBytes()))),
         "c4",
         ByteBuffer.wrap(
             ColumnSerializationUtil.serializeColumn(
-                new Column(
-                    new ColumnMetadata("c4", ColumnDataType.DATETIME, false, 3, ""), null))));
+                new Column(new ColumnMetadata("c4", ColumnDataType.DATETIME, false, 3), null))));
   }
 }

--- a/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/event/mapper/MysqlMutationMapperTest.java
+++ b/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/event/mapper/MysqlMutationMapperTest.java
@@ -61,10 +61,10 @@ public class MysqlMutationMapperTest {
           "test_db",
           null,
           ImmutableList.of(
-              new ColumnMetadata("id", ColumnDataType.LONGLONG, true, 0, ""),
-              new ColumnMetadata("name", ColumnDataType.VARCHAR, false, 1, ""),
-              new ColumnMetadata("age", ColumnDataType.INT24, false, 2, ""),
-              new ColumnMetadata("sex", ColumnDataType.TINY, false, 3, "")),
+              new ColumnMetadata("id", ColumnDataType.LONGLONG, true, 0),
+              new ColumnMetadata("name", ColumnDataType.VARCHAR, false, 1),
+              new ColumnMetadata("age", ColumnDataType.INT24, false, 2),
+              new ColumnMetadata("sex", ColumnDataType.TINY, false, 3)),
           ImmutableList.of("id"));
 
   private final AtomicReference<Transaction> beginTransaction = new AtomicReference<>();

--- a/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/mutation/MysqlKeyProviderTest.java
+++ b/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/mutation/MysqlKeyProviderTest.java
@@ -24,7 +24,7 @@ public class MysqlKeyProviderTest {
           "users",
           "test",
           null,
-          ImmutableList.of(new ColumnMetadata(ID_COLUMN, ColumnDataType.LONGLONG, true, 0, "")),
+          ImmutableList.of(new ColumnMetadata(ID_COLUMN, ColumnDataType.LONGLONG, true, 0)),
           ImmutableList.of(ID_COLUMN));
 
   private static final MysqlMutationMetadata MUTATION_METADATA =

--- a/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/validator/MutationSchemaValidatorTest.java
+++ b/spinaltap-mysql/src/test/java/com/airbnb/spinaltap/mysql/validator/MutationSchemaValidatorTest.java
@@ -29,9 +29,9 @@ public class MutationSchemaValidatorTest {
           "test_db",
           null,
           ImmutableList.of(
-              new ColumnMetadata(ID_COLUMN, ColumnDataType.LONGLONG, true, 0, ""),
-              new ColumnMetadata(NAME_COLUMN, ColumnDataType.VARCHAR, false, 1, ""),
-              new ColumnMetadata(AGE_COLUMN, ColumnDataType.INT24, false, 2, "")),
+              new ColumnMetadata(ID_COLUMN, ColumnDataType.LONGLONG, true, 0),
+              new ColumnMetadata(NAME_COLUMN, ColumnDataType.VARCHAR, false, 1),
+              new ColumnMetadata(AGE_COLUMN, ColumnDataType.INT24, false, 2)),
           ImmutableList.of(ID_COLUMN));
 
   private static final MysqlMutationMetadata MUTATION_METADATA =
@@ -105,6 +105,6 @@ public class MutationSchemaValidatorTest {
 
   private Column createColumn(
       String name, ColumnDataType dataType, boolean isPk, Serializable value, int position) {
-    return new Column(new ColumnMetadata(name, dataType, isPk, position, ""), value);
+    return new Column(new ColumnMetadata(name, dataType, isPk, position), value);
   }
 }


### PR DESCRIPTION
there are too many places call the constructor in treehouse, thus make the new field optional

@zuofei @erluoli 