### PR TITLE
add lock for schema manager to avoid race condiftion

### DIFF
--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/schema/MysqlSchemaManager.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/schema/MysqlSchemaManager.java
@@ -175,7 +175,7 @@ public class MysqlSchemaManager implements MysqlSchemaArchiver {
     return isTableColumnChanged;
   }
 
-  public void initialize(BinlogFilePos pos) {
+  public synchronized void initialize(BinlogFilePos pos) {
     if (!isSchemaVersionEnabled) {
       log.info("Schema versioning is not enabled for {}", sourceName);
       return;
@@ -227,7 +227,7 @@ public class MysqlSchemaManager implements MysqlSchemaArchiver {
   }
 
   @Override
-  public void archive() {
+  public synchronized void archive() {
     if (!isSchemaVersionEnabled) {
       log.info("Schema versioning is not enabled for {}", sourceName);
       return;


### PR DESCRIPTION
if these two action happens concurrently, the schema store could be messed up. thus add locking to ensure the consistency of schema store.

@zuofei @BenMusch @erluoli 