### PR TITLE
Use empty database when database in binlog ddl event is set to system databases

### DIFF
--- a/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/MysqlSource.java
+++ b/spinaltap-mysql/src/main/java/com/airbnb/spinaltap/mysql/MysqlSource.java
@@ -131,6 +131,7 @@ public abstract class MysqlSource extends AbstractDataStoreSource<BinlogEvent> {
     tableCache.clear();
 
     MysqlSourceState state = getSavedState();
+    log.info("Initializing source {} with saved state {}.", name, state);
 
     lastSavedState.set(state);
     lastTransaction.set(


### PR DESCRIPTION
Set database to be null in following 2 cases:
1. It could be a new database which has not been created in schema store database, so don't switch to any database before applying database DDL.
2. It could be a system database while DDL uses the fully qualified table name (db.table). E.g. User can apply DDL "CREATE TABLE DB.TABLE xxx" while the database set in current session is "sys".

In either case, `addSourcePrefix` inside `applyDDL` will add the source prefix to the database name (sourceName/databaseName) so that it will be properly tracked in schema database